### PR TITLE
feat: Add test to check order of objects in the source data has no affect on relative duration resolving

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1020,6 +1020,60 @@ const testData = {
 			LLayer: 1
 		}
 	],
+	'relativedurationorder0': [
+		{
+			id: 'group0', // the id must be unique
+
+			trigger: {
+				type: TriggerType.TIME_ABSOLUTE,
+				value: now
+			},
+			duration: '#group1.start - #.start', // stop with start of child1
+			LLayer: 1,
+			isGroup: true,
+			repeating: false,
+			content: {
+				objects: [
+					{
+						id: 'child0', // the id must be unique
+
+						trigger: {
+							type: TriggerType.TIME_ABSOLUTE,
+							value: 0 // Relative to parent object
+						},
+						duration: 0,
+						LLayer: 1
+					}
+				]
+			}
+		},
+		{
+			id: 'group1', // the id must be unique
+
+			trigger: {
+				type: TriggerType.TIME_ABSOLUTE,
+				value: now + 150
+			},
+			duration: 0, // infinite
+			LLayer: 2,
+			isGroup: true,
+			repeating: false,
+			content: {
+				objects: [
+					{
+						id: 'child1', // the id must be unique
+
+						trigger: {
+							type: TriggerType.TIME_ABSOLUTE,
+							value: 0 // Relative to parent object
+						},
+						duration: 0,
+						LLayer: 2
+					}
+				]
+			}
+		}
+	],
 	'circulardependency0': [
 		{
 			id: 'obj0', // the id must be unique
@@ -2031,6 +2085,28 @@ test('relative durations', () => {
 
 	const state5 = Resolver.getState(data, 5401)
 	expect(state5.LLayers['1']).toBeFalsy()
+})
+test('relative durations object order', () => {
+	const data = clone(getTestData('relativedurationorder0'))
+	const tl = Resolver.getTimelineInWindow(data)
+	expect(tl.resolved).toHaveLength(2)
+
+	const events = Resolver.getNextEvents(data, 1000)
+	expect(events.length).toEqual(3)
+	expect(events[0].time).toEqual(1000)
+	expect(events[1].time).toEqual(1150)
+	expect(events[2].time).toEqual(1150)
+
+	const state0 = Resolver.getState(data, 1030)
+	expect(state0.LLayers['1']).toBeTruthy()
+	expect(state0.LLayers['1'].id).toEqual('child0')
+	expect(state0.LLayers['2']).toBeFalsy()
+
+	const state1 = Resolver.getState(data, 1170)
+	expect(state1.LLayers['2']).toBeTruthy()
+	expect(state1.LLayers['2'].id).toEqual('child1')
+	expect(state1.LLayers['1']).toBeFalsy()
+
 })
 test('Circular dependency', () => {
 	const data = clone(getTestData('circulardependency0'))


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds a test for the relative durations, to ensure that the order of the objects in the timeline data array has no effect on the resolved durations


* **What is the current behavior?** (You can also link to an open issue here)
Whether the test passes depends on the order of the groups.
It fails if group1 is after group0, but passes if group1 is before group0.
It should not matter what order they are in, and should resolve the same both ways.

