### PR TITLE
Ensure behaviour is consistent with source data in any order

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1560,7 +1560,8 @@ let tests: Tests = {
 		expect(state0.LLayers['1']).toBeTruthy() // TimelineObject
 		expect(state0.LLayers['1'].id).toBe('obj0')
 
-		data[0].externalFunction = 'ext0'
+		const obj0: TimelineObject = _.findWhere(data, { id: 'obj0' })
+		obj0.externalFunction = 'ext0'
 
 		const externalFunctions0: ExternalFunctions = {
 			'ext0': jest.fn((resolvedObj: TimelineResolvedObject, state: TimelineState, tld: DevelopedTimeline) => {
@@ -1667,7 +1668,8 @@ let tests: Tests = {
 	'disabled objects on timeline': () => {
 
 		const data = clone(getTestData('basic'))
-		data[0].disabled = true
+		const obj0: TimelineObject = _.findWhere(data, { id: 'obj0' })
+		obj0.disabled = true
 
 		const tl = Resolver.getTimelineInWindow(data)
 

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1131,7 +1131,6 @@ let tests: Tests = {
 	'Basic timeline': () => {
 
 		const data = getTestData('basic')
-
 		const tl = Resolver.getTimelineInWindow(data)
 		expect(data).toEqual(getTestData('basic')) // Make sure the original data is unmodified
 
@@ -1731,7 +1730,6 @@ let tests: Tests = {
 		}).toThrowError()
 	},
 	'simple group': () => {
-
 		const data = clone(getTestData('simplegroup'))
 
 		const tl = Resolver.getTimelineInWindow(data)
@@ -1743,7 +1741,19 @@ let tests: Tests = {
 		expect(tld.resolved).toHaveLength(3)
 		expect(tld.unresolved).toHaveLength(0)
 
+		const child0: TimelineResolvedObject = _.findWhere(tld.resolved, { id: 'child0' })
+		const child1: TimelineResolvedObject = _.findWhere(tld.resolved, { id: 'child1' })
+		const obj1: TimelineResolvedObject = _.findWhere(tld.resolved, { id: 'obj1' })
+
+		expect(child0.resolved.startTime).toBe(990)
+		expect(child0.resolved.endTime).toBe(1005)
+		expect(child1.resolved.startTime).toBe(1005)
+		expect(child1.resolved.endTime).toBe(1015)
+		expect(obj1.resolved.startTime).toBe(1050)
+
 		const events0 = Resolver.getNextEvents(tl, now)
+		// console.log('tld', tld.resolved)
+		// console.log('events0', events0)
 		expect(events0).toHaveLength(5)
 		const state0 = Resolver.getState(tl, now)
 		expect(state0.LLayers['2']).toBeTruthy()
@@ -2110,7 +2120,8 @@ let tests: Tests = {
 		const tl = Resolver.getTimelineInWindow(data)
 		expect(tl.resolved).toHaveLength(0)
 
-		data[0].duration = 10 // break the circular dependency
+		const obj0: TimelineResolvedObject = _.findWhere(data, { id: 'obj0' })
+		obj0.duration = 10 // break the circular dependency
 
 		const tl2 = Resolver.getTimelineInWindow(data)
 		expect(tl2.resolved).toHaveLength(3)

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -2130,6 +2130,16 @@ let tests: Tests = {
 		const data = clone(getTestData('relativedurationorder0'))
 		const tl = Resolver.getTimelineInWindow(data)
 		expect(tl.resolved).toHaveLength(2)
+		const tld = Resolver.developTimelineAroundTime(tl, now)
+		expect(tld.resolved).toHaveLength(2)
+
+		const child0: TimelineResolvedObject = _.findWhere(tld.resolved, { id: 'child0' })
+		const child1: TimelineResolvedObject = _.findWhere(tld.resolved, { id: 'child1' })
+
+		expect(child0.resolved.startTime).toBe(1000)
+		expect(child0.resolved.endTime).toBe(1150)
+		expect(child1.resolved.startTime).toBe(1150)
+		expect(child1.resolved.endTime).toBe(0)
 
 		const events = Resolver.getNextEvents(data, 1000)
 		expect(events.length).toEqual(3)

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -90,6 +90,7 @@ export interface ResolvedDetails {
 	repeatingStartTime?: StartTime,
 
 	templateData?: any
+	developed?: boolean
 
 	[key: string]: any
 }
@@ -578,8 +579,13 @@ function developTimelineAroundTime (tl: ResolvedTimeline,time: SomeTime): Develo
 
 	return tl2
 }
-function getParentTime (obj: TimelineResolvedObject) {
-	let time = 0
+function getParentStartTime (
+	obj: TimelineResolvedObject,
+	resolveParentStartTime?: boolean,
+	resolvedObjects?: ResolvedObjectsStore,
+	resolveObjectTouches?: ResolvedObjectTouches
+): StartTime {
+	let time: StartTime = null
 	if (
 		_.has(obj.resolved,'repeatingStartTime') &&
 		obj.resolved.repeatingStartTime
@@ -588,17 +594,31 @@ function getParentTime (obj: TimelineResolvedObject) {
 
 	} else if (obj.resolved.startTime) {
 		time = obj.resolved.startTime
+	} else {
+		// if (resolveParentStartTime) {
+		if (resolvedObjects && resolveObjectTouches) {
+			time = resolveObjectStartTime(obj, resolvedObjects, resolveObjectTouches)
+		}
+		// }
 	}
+	if (time === null) return time
 
-	if (obj.parent) {
-		time += getParentTime(obj.parent) - (obj.parent.resolved.startTime || 0)
+	if (obj.parent && !obj.resolved.developed) {
+		const parentTime = getParentStartTime(
+			obj.parent,
+			resolveParentStartTime,
+			resolvedObjects,
+			resolveObjectTouches
+		)
+		if (parentTime === null) return null
+		time += parentTime - (obj.parent.resolved.startTime || 0)
 	}
-
+	log('getParentStartTime ' + obj.id + ' ' + time, TraceLevel.TRACE)
 	return time
 }
 function developObj (tl2: DevelopedTimeline, time: SomeTime, objOrg: TimelineResolvedObject, givenParentObj?: TimelineResolvedObject) {
 	// Develop and place on tl2:
-	log('developObj',TraceLevel.TRACE)
+	log('developObj ' + objOrg.id + ' ' + time,TraceLevel.TRACE)
 
 	const returnObj = _.clone(objOrg)
 	returnObj.resolved = _.clone(returnObj.resolved)
@@ -607,42 +627,56 @@ function developObj (tl2: DevelopedTimeline, time: SomeTime, objOrg: TimelineRes
 	returnObj.resolved.innerEndTime = returnObj.resolved.endTime
 
 	const parentObj = givenParentObj || returnObj.parent
-	let parentTime = 0
+
 	let parentIsRepeating = false
 	if (parentObj) {
-		parentTime = getParentTime(parentObj)
 		returnObj.resolved.parentId = parentObj.id
 
 		parentIsRepeating = (
 			_.has(parentObj.resolved,'repeatingStartTime') &&
 			parentObj.resolved.repeatingStartTime !== null
 		)
+		if (!returnObj.resolved.developed) {
+			let parentTime: StartTime = 0
+			parentTime = getParentStartTime(parentObj)
+			returnObj.resolved.startTime = (returnObj.resolved.startTime || 0) + (parentTime || 0)
+			if (returnObj.resolved.endTime) {
+				returnObj.resolved.endTime += (parentTime || 0)
+			}
+			returnObj.resolved.developed = true
+		} else if (
+			parentObj.resolved.repeatingStartTime &&
+			parentObj.resolved.startTime &&
+			returnObj.resolved.startTime &&
+			returnObj.resolved.endTime
+		) {
+			// parent is repeating, move our startTime forward then
+			const moveForward = parentObj.resolved.repeatingStartTime - parentObj.resolved.startTime
+			if (moveForward > 0) {
+				returnObj.resolved.startTime += moveForward
+				returnObj.resolved.endTime += moveForward
+			}
+		}
 	}
-
-	returnObj.resolved.startTime = (returnObj.resolved.startTime || 0) + parentTime
-
-	if (returnObj.resolved.endTime) {
-		returnObj.resolved.endTime += parentTime
-	}
-
 	if (
 		parentObj &&
 		parentIsRepeating &&
+		parentObj.resolved.innerDuration &&
 		returnObj.resolved.endTime &&
 		returnObj.resolved.startTime &&
-		parentObj.resolved.innerDuration &&
 		returnObj.resolved.endTime < time
 	) {
 		// The object's playtime has already passed, move forward then:
+
 		returnObj.resolved.startTime += parentObj.resolved.innerDuration
 		returnObj.resolved.endTime += parentObj.resolved.innerDuration
 	}
 
 	// cap inside parent:
 	if (parentObj &&
-		returnObj.resolved &&
 		parentObj.resolved &&
 		parentObj.resolved.endTime &&
+		returnObj.resolved &&
 		(
 			(returnObj.resolved.endTime || 0) > parentObj.resolved.endTime ||
 			!returnObj.resolved.endTime // infinite
@@ -653,9 +687,9 @@ function developObj (tl2: DevelopedTimeline, time: SomeTime, objOrg: TimelineRes
 
 	if (
 		parentObj &&
-		returnObj.resolved.startTime &&
 		parentObj.resolved.endTime &&
 		parentObj.resolved.startTime &&
+		returnObj.resolved.startTime &&
 		returnObj.resolved.endTime &&
 		(
 			returnObj.resolved.startTime > parentObj.resolved.endTime ||
@@ -719,15 +753,27 @@ function resolveObjectStartTime (
 
 	if (obj.trigger.type === TriggerType.TIME_ABSOLUTE) {
 
-		let val: number
+		let startTime: number
 		if (_.isNumber(obj.trigger.value)) {
-			val = obj.trigger.value
+			startTime = obj.trigger.value
 		} else {
-			val = parseFloat(obj.trigger.value + '')
+			startTime = parseFloat(obj.trigger.value + '')
+		}
+		if (obj.parent && typeof obj.parent === 'object') {
+			const parentTime = getParentStartTime(
+				obj.parent,
+				true,
+				resolvedObjects,
+				resolveObjectTouches
+			)
+			if (parentTime !== null) {
+				startTime = startTime + parentTime
+			}
 		}
 
 		// Easy, return the absolute time then:
-		obj.resolved.startTime = val
+		obj.resolved.startTime = startTime
+		obj.resolved.developed = true
 
 	} else if (obj.trigger.type === TriggerType.TIME_RELATIVE) {
 		// ooh, it's a relative time! Relative to what, one might ask? Let's find out:
@@ -735,6 +781,7 @@ function resolveObjectStartTime (
 		if (!_.has(obj.resolved,'startTime') || obj.resolved.startTime === null) {
 			const o = decipherTimeRelativeValue(obj.trigger.value + '', resolvedObjects, obj)
 			obj.resolved.startTime = (o ? o.value : null)
+			obj.resolved.developed = true
 			updateReferralIndex(obj, (o ? o.referralIndex : null))
 			updateReferredObjectIds(obj, (o ? o.referredObjectIds : null), resolvedObjects)
 		}
@@ -790,24 +837,30 @@ function resolveObjectDuration (
 				unresolvedObjects: [],
 				resolvedObjects: []
 			}
+			const startTime = resolveObjectStartTime(obj, resolvedObjects, resolveObjectTouches)
 
 			log('RESOLVE GROUP DURATION ' + obj.id,TraceLevel.TRACE)
 			// let lastEndTime: EndTime = -1
 			// let hasInfiniteDuration = false
-			if (obj.content && obj.content.objects) {
-				// let obj = clone(obj)
-				if (!obj.content.hasClonedChildren) { // we should clone out children, so that we wont affect the original objects
-					obj.content.hasClonedChildren = true
-					obj.content.objects = _.map(obj.content.objects, (o: any) => {
-						const o2 = _.clone(o)
-						o2.content = _.clone(o2.content)
-						return o2
-					})
+			if (startTime) {
+				if (obj.content && obj.content.objects) {
+					// let obj = clone(obj)
+					if (!obj.content.hasClonedChildren) { // we should clone out children, so that we wont affect the original objects
+						obj.content.hasClonedChildren = true
+						obj.content.objects = _.map(obj.content.objects, (o: any) => {
+							const o2 = _.clone(o)
+							o2.content = _.clone(o2.content)
+							return o2
+						})
+					}
+					result = iterateResolveObjects(obj.content.objects, resolvedObjects, resolveObjectTouches, obj0)
+					obj.content.objects = result.resolvedObjects.concat(result.unresolvedObjects as Array<any>)
 				}
-				result = iterateResolveObjects(obj.content.objects, resolvedObjects, resolveObjectTouches, obj0)
-				obj.content.objects = result.resolvedObjects.concat(result.unresolvedObjects as Array<any>)
+			} else {
+				log('Cannot resolve group duration, has no own startTime ' + obj.id,TraceLevel.TRACE)
 			}
-			innerDuration = result.lastEndTime || 0
+
+			innerDuration = (result.lastEndTime || 0) - (startTime || 0)
 			obj.resolved.innerDuration = innerDuration
 			const duration = resolveDuration(obj)
 			if (duration !== null) {
@@ -1142,11 +1195,30 @@ function resolveExpression (
 					obj: TimelineResolvedObject | TimelineResolvedKeyframe,
 					resolvedObjects: ResolvedObjectsStore
 				): StartTime => {
-					return (
+
+					let startTime = (
 						_.has(obj.resolved,'startTime') ?
 						(obj.resolved.startTime || 0) :
 						resolveObjectStartTime(obj, resolvedObjects, resolveObjectTouches)
 					)
+					if (startTime !== null) {
+
+						if (!obj.resolved.developed) {
+							if (obj.parent && typeof obj.parent === 'object') {
+								const parentTime = getParentStartTime(
+									obj.parent,
+									true,
+									resolvedObjects,
+									resolveObjectTouches
+								)
+								if (parentTime !== null) {
+									startTime = startTime + parentTime
+								}
+							}
+						}
+					}
+
+					return startTime
 				}
 				const getReferredDuration = (
 					obj: TimelineResolvedObject | TimelineResolvedKeyframe,
@@ -1176,6 +1248,7 @@ function resolveExpression (
 
 				ctx.touchedObjectExpressions[expression] = val
 
+				log('val ' + val, TraceLevel.TRACE)
 				return val
 			}
 		}


### PR DESCRIPTION
This makes the behaviour consistent no matter the order of the source data.

It also adds a breaking change, when referring to an object within a group, now you get the absolute time, not the local time within that group