### PR TITLE
chore: Add test to verify operator order

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1384,6 +1384,71 @@ const testData = {
 				]
 			}
 		}
+	],
+	'operatorOrder': [
+		{
+			id: 'obj0',
+			trigger: {
+				type: TriggerType.TIME_ABSOLUTE,
+				value: now + 3000
+			},
+			duration: 0,
+			LLayer: 0
+		},
+		{
+			id: 'obj1',
+			trigger: {
+				type: TriggerType.TIME_ABSOLUTE,
+				value: now
+			},
+			duration: '(#obj0.start - #.start) - 2000',
+			LLayer: 1
+		},
+		{
+			id: 'obj2',
+			trigger: {
+				type: TriggerType.TIME_ABSOLUTE,
+				value: now
+			},
+			duration: '#obj0.start - 2000 - #.start',
+			LLayer: 2
+		},
+		{
+			id: 'obj3',
+			trigger: {
+				type: TriggerType.TIME_ABSOLUTE,
+				value: now
+			},
+			duration: '#obj0.start - #.start - 2000',
+			LLayer: 3
+		},
+		{
+			id: 'obj4',
+			trigger: {
+				type: TriggerType.TIME_ABSOLUTE,
+				value: now
+			},
+			duration: '(#obj0.start - #.start) + 2000',
+			LLayer: 4
+		},
+		{
+			id: 'obj5',
+			trigger: {
+				type: TriggerType.TIME_ABSOLUTE,
+				value: now
+			},
+			duration: '#obj0.start + 2000 - #.start',
+			LLayer: 5
+		},
+		{
+			id: 'obj6',
+			trigger: {
+				type: TriggerType.TIME_ABSOLUTE,
+				value: now
+			},
+			duration: '#obj0.start - #.start + 2000',
+			LLayer: 6
+		}
 	]
 }
 let reverseData = false
@@ -2631,6 +2696,41 @@ let tests: Tests = {
 		const state0 = Resolver.getState(data, 5500)
 		expect(state0.LLayers['4']).toBeFalsy()
 		expect(state0.LLayers['6']).toBeFalsy()
+	},
+	'Operator order': () => {
+		const data = clone(getTestData('operatorOrder'))
+		const tl = Resolver.getTimelineInWindow(data)
+		expect(tl.unresolved).toHaveLength(0)
+		expect(tl.resolved).toHaveLength(7)
+
+		const obj0: TimelineResolvedObject = _.findWhere(tl.resolved, { id: 'obj0' })
+		const obj1: TimelineResolvedObject = _.findWhere(tl.resolved, { id: 'obj1' })
+		const obj2: TimelineResolvedObject = _.findWhere(tl.resolved, { id: 'obj2' })
+		const obj3: TimelineResolvedObject = _.findWhere(tl.resolved, { id: 'obj3' })
+		const obj4: TimelineResolvedObject = _.findWhere(tl.resolved, { id: 'obj4' })
+		const obj5: TimelineResolvedObject = _.findWhere(tl.resolved, { id: 'obj5' })
+		const obj6: TimelineResolvedObject = _.findWhere(tl.resolved, { id: 'obj6' })
+
+		expect(obj0.resolved.startTime).toBe(4000)
+		expect(obj0.resolved.outerDuration).toBe(0)
+
+		expect(obj1.resolved.startTime).toBe(1000)
+		expect(obj1.resolved.outerDuration).toBe(1000)
+
+		expect(obj2.resolved.startTime).toBe(1000)
+		expect(obj2.resolved.outerDuration).toBe(1000)
+
+		expect(obj3.resolved.startTime).toBe(1000)
+		expect(obj3.resolved.outerDuration).toBe(1000)
+
+		expect(obj4.resolved.startTime).toBe(1000)
+		expect(obj4.resolved.outerDuration).toBe(5000)
+
+		expect(obj5.resolved.startTime).toBe(1000)
+		expect(obj5.resolved.outerDuration).toBe(5000)
+
+		expect(obj6.resolved.startTime).toBe(1000)
+		expect(obj6.resolved.outerDuration).toBe(5000)
 	}
 }
 const onlyTests: Tests = {}


### PR DESCRIPTION
The durations are being calculated as:

(4000 - 1000) - 2000 = 1000 (correct)
4000 - 2000 - 1000 = 3000 (wrong. expected 1000)
4000 - 1000 - 2000 = 5000 (wrong. expected 1000)

(4000 - 1000) + 2000 = 5000 (correct)
4000 + 2000 - 1000 = 5000 (correct)
4000 - 1000 + 2000 = 5000 (correct)

Looks like the - operator is being prioritised over + and being evaluated right to left? 