### PR TITLE
chore: Add test using nested parentheses

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1384,6 +1384,26 @@ const testData = {
 				]
 			}
 		}
+	],
+	'manyParentheses': [
+		{
+			id: 'obj0',
+			trigger: {
+				type: TriggerType.TIME_ABSOLUTE,
+				value: now + 3000
+			},
+			duration: 0,
+			LLayer: 0
+		},
+		{
+			id: 'obj1',
+			trigger: {
+				type: TriggerType.TIME_ABSOLUTE,
+				value: now
+			},
+			duration: '((#obj0.start - #.start) - (1000 + (2000 / 2)))',
+			LLayer: 1
+		}
 	]
 }
 let reverseData = false
@@ -2631,6 +2651,21 @@ let tests: Tests = {
 		const state0 = Resolver.getState(data, 5500)
 		expect(state0.LLayers['4']).toBeFalsy()
 		expect(state0.LLayers['6']).toBeFalsy()
+	},
+	'Many parentheses': () => {
+		const data = clone(getTestData('manyParentheses'))
+		const tl = Resolver.getTimelineInWindow(data)
+		expect(tl.unresolved).toHaveLength(0)
+		expect(tl.resolved).toHaveLength(2)
+
+		const obj0: TimelineResolvedObject = _.findWhere(tl.resolved, { id: 'obj0' })
+		const obj1: TimelineResolvedObject = _.findWhere(tl.resolved, { id: 'obj1' })
+
+		expect(obj0.resolved.startTime).toBe(4000)
+		expect(obj0.resolved.outerDuration).toBe(0)
+
+		expect(obj1.resolved.startTime).toBe(1000)
+		expect(obj1.resolved.outerDuration).toBe(1000)
 	}
 }
 const onlyTests: Tests = {}

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1956,8 +1956,28 @@ let tests: Tests = {
 		)).toEqual(3)
 
 		expect(Resolver.resolveExpression(
+			Resolver.interpretExpression('5 + 4 - 2 + 1 - 5 + 7')
+		)).toEqual(10)
+
+		expect(Resolver.resolveExpression(
+			Resolver.interpretExpression('5 - 4 - 3')
+		)).toEqual(-2)
+
+		expect(Resolver.resolveExpression(
+			Resolver.interpretExpression('5 - 4 - 3 - 10 + 2')
+		)).toEqual(-10)
+
+		expect(Resolver.resolveExpression(
 			Resolver.interpretExpression('4 * 5.5')
 		)).toEqual(22)
+
+		expect(Resolver.resolveExpression(
+			Resolver.interpretExpression('2 * 3 * 4')
+		)).toEqual(24)
+
+		expect(Resolver.resolveExpression(
+			Resolver.interpretExpression('20 / 4 / 2')
+		)).toEqual(2.5)
 
 		expect(Resolver.resolveExpression(
 			Resolver.interpretExpression('2 * (2 + 3) - 2 * 2')

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -989,7 +989,6 @@ function interpretExpression (strOrExpr: string | number | Expression, isLogical
 			}
 
 			const tmp = wrapInnerExpressions(words)
-
 			if (tmp.rest.length) throw new Error('interpretExpression: syntax error: parentheses don\'t add up in "' + str + '".')
 
 			const expressionArray = tmp.inner
@@ -1011,7 +1010,7 @@ function interpretExpression (strOrExpr: string | number | Expression, isLogical
 				// Find the operator with the highest priority:
 				_.each(operatorList,function (operator) {
 					if (operatorI === -1) {
-						operatorI = words.indexOf(operator)
+						operatorI = words.lastIndexOf(operator)
 					}
 				})
 
@@ -1099,7 +1098,8 @@ function resolveExpression (
 
 		const expression: ExpressionObj = expression0 as ExpressionObj
 
-		log('resolveExpression',TraceLevel.TRACE)
+		// @ts-ignore stringify
+		log('resolveExpression' + JSON.stringify(expression0, '', 2), TraceLevel.TRACE)
 
 		const l = resolveExpression(expression.l, whosAsking, getObjectAttribute)
 		const r = resolveExpression(expression.r, whosAsking, getObjectAttribute)
@@ -1116,6 +1116,8 @@ function resolveExpression (
 		if (expression.o === '*') return l * r
 		if (expression.o === '/') return l / r
 	} else {
+
+		log('resolveExpression' + expression0, TraceLevel.TRACE)
 
 		if (isNumeric(expression0)) {
 			if (_.isNumber(expression0)) {

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -974,7 +974,7 @@ function interpretExpression (strOrExpr: string | number | Expression, isLogical
 
 						// insert inner expression and remove tha
 						words[i] = tmp.inner
-						words.splice(i + 1,tmp.inner.length + 1)
+						words.splice(i + 1, 99999, ...tmp.rest)
 					} else if (words[i] === ')') {
 						return {
 							inner: words.slice(0,i),


### PR DESCRIPTION
The example is perfectly valid:
```
(
	(
		#obj0.start
		-
		#.start
	)
	-
	(
		1000
		+
		(
			2000
			/
			2
		)
	)
)
```

It appears to fall down when they are nested, so `(#obj0.start - #.start) - (1000 + 2000 / 2)` works but `(#obj0.start - #.start) - (1000 + (2000 / 2))` does not