### PR TITLE
chore: Add test for child starting before parent group

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -3054,7 +3054,7 @@ let tests: Tests = {
 		const group0: TimelineResolvedObject = _.findWhere(tl.resolved, { id: 'group0' })
 
 		expect(group0.resolved.startTime).toBe(6000)
-		expect(group0.resolved.outerDuration).toBe(0)
+		expect(group0.resolved.outerDuration).toBe(Infinity)
 
 		const events = Resolver.getNextEvents(data, 1000)
 		expect(events.length).toEqual(2)

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -2770,8 +2770,4 @@ describe('Tests with reversed data', () => {
 	})
 })
 
-// TOOD: test group
-
-// TODO: test looping group
-
 // TODO: test .useExternalFunctions

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1551,6 +1551,42 @@ const testData = {
 			duration: '#obj0.start - #.start + 2000',
 			LLayer: 6
 		}
+	],
+	'childWithStartBeforeParent': [
+		{
+			id: 'group0', // the id must be unique
+
+			trigger: {
+				type: TriggerType.TIME_ABSOLUTE,
+				value: now + 5000
+			},
+			duration: 0,
+			LLayer: 1,
+			isGroup: true,
+			repeating: false,
+			content: {
+				objects: [
+					{
+						id: 'child0',
+						trigger: {
+							type: TriggerType.TIME_ABSOLUTE,
+							value: -1000 // Relative to parent object
+						},
+						duration: 0,
+						LLayer: 2
+					},
+					{
+						id: 'child1',
+						trigger: {
+							type: TriggerType.TIME_RELATIVE,
+							value: '#group0.start - 1000'
+						},
+						duration: 0,
+						LLayer: 3
+					}
+				]
+			}
+		}
 	]
 }
 let reverseData = false
@@ -2898,6 +2934,24 @@ let tests: Tests = {
 
 		expect(obj6.resolved.startTime).toBe(1000)
 		expect(obj6.resolved.outerDuration).toBe(5000)
+	},
+	'Child with a start before parent': () => {
+		const data = clone(getTestData('childWithStartBeforeParent'))
+		const tl = Resolver.getTimelineInWindow(data)
+		expect(tl.unresolved).toHaveLength(0)
+		expect(tl.resolved).toHaveLength(1)
+
+		const group0: TimelineResolvedObject = _.findWhere(tl.resolved, { id: 'group0' })
+
+		expect(group0.resolved.startTime).toBe(6000)
+		expect(group0.resolved.outerDuration).toBe(0)
+
+		const events = Resolver.getNextEvents(data, 1000)
+		expect(events.length).toEqual(2)
+		expect(events[0].obj.id).toEqual('child1')
+		expect(events[0].time).toEqual(6000)
+		expect(events[1].obj.id).toEqual('child0')
+		expect(events[1].time).toEqual(6000)
 	}
 }
 const onlyTests: Tests = {}

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -1384,6 +1384,88 @@ const testData = {
 				]
 			}
 		}
+	],
+	'childEndRelativeParentEnd': [
+		{
+			id: 'group0', // the id must be unique
+
+			trigger: {
+				type: TriggerType.TIME_ABSOLUTE,
+				value: now
+			},
+			duration: '#group3.start + 600 - #.start',
+			LLayer: 2,
+			isGroup: true,
+			repeating: false,
+			content: {
+				objects: [
+					{
+						id: 'group2', // the id must be unique
+						trigger: {
+							type: TriggerType.TIME_ABSOLUTE,
+							value: 0
+						},
+						duration: '(#group0.end - #.start) - 2000',
+						LLayer: 3,
+						isGroup: true,
+						repeating: false,
+						content: {
+							objects: [
+								{
+									id: 'child1', // the id must be unique
+									trigger: {
+										type: TriggerType.TIME_ABSOLUTE,
+										value: 0 // Relative to parent object
+									},
+									duration: 0,
+									LLayer: 4
+								}
+							]
+						}
+					}
+				]
+			}
+		},
+		{
+			id: 'group1', // the id must be unique
+
+			trigger: {
+				type: TriggerType.TIME_ABSOLUTE,
+				value: now + 5000
+			},
+			duration: 0,
+			LLayer: 1,
+			isGroup: true,
+			repeating: false,
+			content: {
+				objects: [
+					{
+						id: 'group3', // the id must be unique
+						trigger: {
+							type: TriggerType.TIME_ABSOLUTE,
+							value: 0
+						},
+						duration: 3600,
+						LLayer: 7,
+						isGroup: true,
+						repeating: false,
+						content: {
+							objects: [
+								{
+									id: 'child0', // the id must be unique
+									trigger: {
+										type: TriggerType.TIME_ABSOLUTE,
+										value: 0
+									},
+									duration: 0,
+									LLayer: 8
+								}
+							]
+						}
+					}
+				]
+			}
+		}
 	]
 }
 let reverseData = false
@@ -2631,6 +2713,36 @@ let tests: Tests = {
 		const state0 = Resolver.getState(data, 5500)
 		expect(state0.LLayers['4']).toBeFalsy()
 		expect(state0.LLayers['6']).toBeFalsy()
+	},
+	'Child relative duration before parent end': () => {
+		const data = clone(getTestData('childEndRelativeParentEnd'))
+		const tl = Resolver.getTimelineInWindow(data)
+		expect(tl.unresolved).toHaveLength(0)
+		expect(tl.resolved).toHaveLength(2)
+
+		const group0: TimelineResolvedObject = _.findWhere(tl.resolved, { id: 'group0' })
+		const group1: TimelineResolvedObject = _.findWhere(tl.resolved, { id: 'group1' })
+
+		expect(group0.resolved.startTime).toBe(1000)
+		expect(group0.resolved.outerDuration).toBe(5600)
+
+		expect(group1.resolved.startTime).toBe(6000)
+		expect(group1.resolved.outerDuration).toBe(0)
+
+		const events = Resolver.getNextEvents(data, 1000)
+		expect(events.length).toEqual(4)
+		expect(events[0].obj.id).toEqual('child1')
+		expect(events[0].time).toEqual(1000)
+		expect(events[1].obj.id).toEqual('child1')
+		expect(events[1].time).toEqual(4600)
+		expect(events[2].obj.id).toEqual('child0')
+		expect(events[2].time).toEqual(6000)
+		expect(events[3].obj.id).toEqual('child0')
+		expect(events[3].time).toEqual(9600)
+
+		const state0 = Resolver.getState(data, 6500)
+		expect(state0.LLayers['4']).toBeFalsy()
+		expect(state0.LLayers['8']).toBeTruthy()
 	}
 }
 const onlyTests: Tests = {}

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -315,6 +315,9 @@ class Resolver {
 			if (a.type > b.type) return -1
 			if (a.type < b.type) return 1
 
+			if (a.obj.id > b.obj.id) return -1
+			if (a.obj.id < b.obj.id) return 1
+
 			return 0
 		})
 


### PR DESCRIPTION
It is possible to have a child object resolving when the parent group does not, by using a negative start offset.
