### PR TITLE
chore: Add test for when relative duration resolves to zero due due t…

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -2720,7 +2720,7 @@ let tests: Tests = {
 		expect(child0.resolved.startTime).toBe(1000)
 		expect(child0.resolved.endTime).toBe(1150)
 		expect(child1.resolved.startTime).toBe(1150)
-		expect(child1.resolved.endTime).toBe(0)
+		expect(child1.resolved.endTime).toBe(Infinity)
 
 		const events = Resolver.getNextEvents(data, 1000)
 		expect(events.length).toEqual(3)
@@ -2844,7 +2844,7 @@ let tests: Tests = {
 		const trans0: TimelineResolvedObject = _.findWhere(tl.resolved, { id: 'trans0' })
 
 		expect(group0.resolved.startTime).toBe(1000)
-		expect(group0.resolved.outerDuration).toBe(0)
+		expect(group0.resolved.outerDuration).toBe(Infinity)
 
 		expect(trans0.resolved.startTime).toBe(1000)
 		expect(trans0.resolved.outerDuration).toBe(2500)
@@ -2856,10 +2856,10 @@ let tests: Tests = {
 		const child1: TimelineResolvedObject = _.findWhere(tld.resolved, { id: 'child1' })
 
 		expect(child0.resolved.startTime).toBe(2500)
-		expect(child0.resolved.outerDuration).toBe(0)
+		expect(child0.resolved.outerDuration).toBe(Infinity)
 
 		expect(child1.resolved.startTime).toBe(1000)
-		expect(child1.resolved.outerDuration).toBe(0)
+		expect(child1.resolved.outerDuration).toBe(Infinity)
 
 		const state0 = Resolver.getState(data, 1500)
 		expect(state0.LLayers['3']).toBeTruthy()
@@ -2886,7 +2886,7 @@ let tests: Tests = {
 		expect(group0.resolved.outerDuration).toBe(3100)
 
 		expect(group1.resolved.startTime).toBe(4000)
-		expect(group1.resolved.outerDuration).toBe(0)
+		expect(group1.resolved.outerDuration).toBe(Infinity)
 
 		const events = Resolver.getNextEvents(data, 1000)
 		expect(events.length).toEqual(3)
@@ -2914,7 +2914,7 @@ let tests: Tests = {
 		expect(group0.resolved.outerDuration).toBe(5600)
 
 		expect(group1.resolved.startTime).toBe(6000)
-		expect(group1.resolved.outerDuration).toBe(0)
+		expect(group1.resolved.outerDuration).toBe(Infinity)
 
 		const events = Resolver.getNextEvents(data, 1000)
 		expect(events.length).toEqual(4)
@@ -2941,17 +2941,19 @@ let tests: Tests = {
 		const group1: TimelineResolvedObject = _.findWhere(tl.resolved, { id: 'group1' })
 
 		expect(group0.resolved.startTime).toBe(1000)
-		expect(group0.resolved.outerDuration).toBe(0)
+		expect(group0.resolved.outerDuration).toBe(Infinity)
 
 		expect(group1.resolved.startTime).toBe(1000)
-		expect(group1.resolved.outerDuration).toBe(0)
+		expect(group1.resolved.outerDuration).toBe(Infinity)
 
 		const events = Resolver.getNextEvents(data, 1000)
-		expect(events.length).toEqual(2)
-		expect(events[0].obj.id).toEqual('child1')
+		expect(events.length).toEqual(3)
+		expect(events[0].obj.id).toEqual('child0')
 		expect(events[0].time).toEqual(1000)
-		expect(events[1].obj.id).toEqual('child0')
+		expect(events[1].obj.id).toEqual('child1')
 		expect(events[1].time).toEqual(1000)
+		expect(events[2].obj.id).toEqual('child0')
+		expect(events[2].time).toEqual(1000)
 
 		const state0 = Resolver.getState(data, 1500)
 		expect(state0.LLayers['3']).toBeTruthy()
@@ -2967,7 +2969,7 @@ let tests: Tests = {
 		const obj1: TimelineResolvedObject = _.findWhere(tl.resolved, { id: 'obj1' })
 
 		expect(obj0.resolved.startTime).toBe(4000)
-		expect(obj0.resolved.outerDuration).toBe(0)
+		expect(obj0.resolved.outerDuration).toBe(Infinity)
 
 		expect(obj1.resolved.startTime).toBe(1000)
 		expect(obj1.resolved.outerDuration).toBe(1000)
@@ -2987,7 +2989,7 @@ let tests: Tests = {
 		const obj6: TimelineResolvedObject = _.findWhere(tl.resolved, { id: 'obj6' })
 
 		expect(obj0.resolved.startTime).toBe(4000)
-		expect(obj0.resolved.outerDuration).toBe(0)
+		expect(obj0.resolved.outerDuration).toBe(Infinity)
 
 		expect(obj1.resolved.startTime).toBe(1000)
 		expect(obj1.resolved.outerDuration).toBe(1000)

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -11,7 +11,7 @@ export interface TimelineObject {
 		type: TriggerType,
 		value: number | string // unix timestamp
 	},
-	duration: number, // seconds
+	duration?: number, // seconds
 	LLayer: string | number,
 	content: {
 		objects?: Array<TimelineObject>,
@@ -53,7 +53,7 @@ export interface TimelineKeyframe {
 		type: TriggerType,
 		value: number | string // unix timestamp
 	},
-	duration: number, // seconds
+	duration?: number, // seconds
 	content?: {
 
 		// templateData?: any,

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -315,6 +315,9 @@ class Resolver {
 			if (a.type > b.type) return -1
 			if (a.type < b.type) return 1
 
+			if (a.obj.id > b.obj.id) return -1
+			if (a.obj.id < b.obj.id) return 1
+
 			return 0
 		})
 

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -146,8 +146,8 @@ export interface Filter {
 	endTime?: EndTime,
 }
 export type WhosAskingTrace = Array<string>
-export type objAttributeFunction = (objId: string, hook: 'start' | 'end' | 'duration' | 'parentStart', whosAsking: WhosAskingTrace) => number | null
-const nullGetObjectAttribute: objAttributeFunction = (_objId, _hook, _whosAsking) => {
+export type objAttributeFunction = (objId: string, hook: 'start' | 'end' | 'duration' | 'parentStart', whosAsking: WhosAskingTrace, supressAlreadyAskedWarning?: boolean) => number | null
+const nullGetObjectAttribute: objAttributeFunction = (_objId, _hook, _whosAsking, _supressAlreadyAskedWarning) => {
 	return null
 }
 class Resolver {
@@ -239,11 +239,12 @@ class Resolver {
 		_.each(tld.resolved, (obj: TimelineResolvedObject) => {
 
 			if (
-				(obj.resolved.endTime || 0) >= time || // the object has not already finished
-				obj.resolved.endTime === 0 // the object has no endTime
+				(obj.resolved.endTime || 0) >= time // the object has not already finished
+				// || obj.resolved.endTime === 0 // the object has no endTime
 			 ) {
 				if (
 					obj.resolved.startTime &&
+					obj.resolved.startTime !== Infinity &&
 					(obj.resolved.startTime || 0) >= time) { // the object has not started yet
 					nextEvents.push({
 						type: EventType.START,
@@ -251,7 +252,10 @@ class Resolver {
 						obj: obj
 					})
 				}
-				if (obj.resolved.endTime) {
+				if (
+					obj.resolved.endTime &&
+					obj.resolved.endTime !== Infinity
+				) {
 
 					nextEvents.push({
 						type: EventType.END,
@@ -834,9 +838,15 @@ function resolveObjectDuration (
 
 		const resolveDuration = (obj: TimelineResolvedObject | TimelineResolvedKeyframe): Duration => {
 			if (_.isString(obj.duration)) {
-				return decipherTimeRelativeValue(obj.duration + '', unshiftAndReturn(whosAsking, obj.id), getObjectAttribute)
+				const d = decipherTimeRelativeValue(obj.duration + '', unshiftAndReturn(whosAsking, obj.id), getObjectAttribute)
+				log('resolved duration: ' + d, TraceLevel.TRACE)
+				return d
 			}
-			return obj.duration || 0
+			if (
+				obj.duration === 0 ||
+				obj.duration === undefined
+			) return Infinity
+			return obj.duration
 		}
 
 		// @ts-ignore check if object is a group
@@ -848,19 +858,16 @@ function resolveObjectDuration (
 
 			let outerDurationSetFromDuration = false
 			if (
-				duration !== null &&
-				(
-					(duration || 0) > 0 ||
-					duration === 0
-				)
+				obj.duration ||
+				obj.duration === 0
 			) {
-				// The outerDuration is, in this case determined by the duration
+				// The outerDuration is, in this case, determined by the duration
 				outerDuration = duration
 				obj.resolved.outerDuration = outerDuration
 				outerDurationSetFromDuration = true
 			}
 
-			let lastEndTime: EndTime = -1
+			let lastEndTime: EndTime = 0
 			if (startTime) {
 				if (obj.content && obj.content.objects) {
 					_.each(obj.content.objects, (child: TimelineResolvedObject) => {
@@ -877,38 +884,41 @@ function resolveObjectDuration (
 			}
 			innerDuration = (
 				lastEndTime ?
-				(lastEndTime || 0) - (startTime || 0) :
+				Math.max(0, (lastEndTime || 0) - (startTime || 0)) || 0 :
 				0
 			)
 			obj.resolved.innerDuration = innerDuration
 
 			if (duration !== null) {
 				if (!outerDurationSetFromDuration) {
-					outerDuration = lastEndTime || 0
+					// outerDuration = lastEndTime || 0
+					outerDuration = innerDuration
 				}
 				obj.resolved.outerDuration = outerDuration
 			}
-			log('GROUP DURATION: ' + obj.resolved.innerDuration + ', ' + obj.resolved.outerDuration,TraceLevel.TRACE)
+			log('GROUP ' + obj.id + ' DURATION: ' + obj.resolved.innerDuration + ', ' + obj.resolved.outerDuration,TraceLevel.TRACE)
 		} else {
 
-			const contentDuration = (obj.content || {}).duration // todo: deprecate this?
+			let contentDuration = (obj.content || {}).duration // todo: deprecate this?
+			if (contentDuration === 0) contentDuration = Infinity
+
 			const duration = resolveDuration(obj)
 			outerDuration = (
-				(duration || 0) > 0 || duration === 0 ?
+				(duration || 0) > 0 ?
 				duration :
 				contentDuration
 			)
 			obj.resolved.outerDuration = outerDuration
 
 			innerDuration = (
-				contentDuration > 0 || contentDuration === 0 ?
+				contentDuration > 0 ?
 				contentDuration :
 				duration
 			)
 			obj.resolved.innerDuration = innerDuration
 		}
-		log('Duration ' + outerDuration + ', ' + innerDuration, TraceLevel.TRACE)
-		getObjectAttribute(obj.id, 'end', whosAsking)
+		log('Duration ' + obj.id + ': ' + outerDuration + ', ' + innerDuration, TraceLevel.TRACE)
+		getObjectAttribute(obj.id, 'end', whosAsking, true)
 	}
 	return outerDuration
 
@@ -928,11 +938,12 @@ function resolveObjectEndTime (
 		startTime !== null &&
 		outerDuration !== null
 	) {
-		if (outerDuration) {
-			endTime = (startTime || 0) + outerDuration
-		} else {
-			endTime = 0 // infinite
-		}
+		endTime = (startTime || 0) + outerDuration
+		// if (outerDuration) {
+		// 		endTime = (startTime || 0) + outerDuration
+		// } else {
+		//  	endTime = 0 // infinite
+		// }
 		obj.resolved.endTime = endTime
 	}
 	return endTime
@@ -1511,7 +1522,7 @@ function decipherLogicalValue (
 
 }
 
-function resolveState (tld: DevelopedTimeline,time: SomeTime): TimelineState {
+function resolveState (tld: DevelopedTimeline, time: SomeTime): TimelineState {
 
 	log('resolveState',TraceLevel.TRACE)
 	const LLayers: {[layerId: string]: TimelineResolvedObject} = {}
@@ -1528,8 +1539,8 @@ function resolveState (tld: DevelopedTimeline,time: SomeTime): TimelineState {
 		log(obj,TraceLevel.TRACE)
 		if (
 			(
-				(obj.resolved.endTime || 0) > time ||
-				obj.resolved.endTime === 0
+				(obj.resolved.endTime || 0) > time
+				// || obj.resolved.endTime === 0
 			) &&
 			(obj.resolved.startTime || 0) <= time &&
 			!obj.resolved.disabled
@@ -1984,7 +1995,8 @@ function createGetObjectAttribute (allObjects: {[id: string]: any}) {
 	const getObjectAttribute: objAttributeFunction = (
 		objId,
 		hook,
-		whosAsking
+		whosAsking,
+		supressAlreadyAskedWarning
 	) => {
 		const key = objId + '_' + hook
 		const obj: TimelineResolvedObject = allObjects[objId]
@@ -2025,7 +2037,9 @@ function createGetObjectAttribute (allObjects: {[id: string]: any}) {
 				throw e
 			} else {
 				// it wasn't possible to determine the startTime
-				log('Already tried, not possible to get', TraceLevel.TRACE)
+				if (!supressAlreadyAskedWarning) {
+					log('Already tried, not possible to get', TraceLevel.TRACE)
+				}
 				return null
 			}
 		}
@@ -2064,8 +2078,10 @@ function isResolvedGood (obj: TimelineResolvedObject | TimelineResolvedKeyframe)
 		const startTime = obj.resolved.startTime
 
 		const startTimeIsOk = (
-			(obj.parent && startTime !== null) || // inside a group, 0 is okay too
-			startTime
+			startTime !== Infinity && (
+				(obj.parent && startTime !== null) || // inside a group, 0 is okay too
+				startTime
+			)
 		)
 
 		const durationIsOk = (


### PR DESCRIPTION
The main problem here looks to be because group0, group1, group0_1 and group1_1 all start at the same time, which means that the duration of group1_1 (`#group0_1.start - #.start`) resolves to 0.
Adding a ` + 1` to the end of the duration causes the resolves to give what I would expect.

In other words, a duration of 0 achieved through relative durations should mean 0 not infinite