### PR TITLE
fix: Allow string llayer ids in logical triggers

### DIFF
--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -1368,10 +1368,6 @@ function resolveLogicalExpression (
 					const m = add.val.match(/([GL])(.*)/i)
 					if (m) {
 
-						if (!isNumeric(m[2])) {
-							err = m[2]
-						}
-
 						if ((m[1] || '').match(/L/i)) { // LLayer
 							const LLayer = (
 								m[2] ?


### PR DESCRIPTION
TimelineObj.LLayer is now defined as `string | number` so logical triggers should allow it to be a string too.