### PR TITLE
add test for class application in state from inactive object

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -161,4 +161,69 @@ describe('index', () => {
 		expect(state2.layers[0].content.attr3).toEqual(undefined)
 
 	})
+	test('class applies when defined multiple places', () => {
+		const timeline: Array<TimelineObject> = [
+			{
+			   'id': 'o1',
+			   'enable': {
+				  'while': '.some_class'
+			   },
+			   'priority': 1,
+			   'layer': 'layer0',
+			   'content': {}
+			},
+			{
+			   'id': 'o5',
+			   'priority': 0.1,
+			   'enable': {
+				  'start': 1
+			   },
+			   'layer': 'layer1',
+			   'classes': [
+				  'some_class'
+			   ],
+			   'content': {}
+			},
+			{
+			   'id': 'g0',
+			   'enable': {
+				  'start': 500,
+				  'end': 1000
+			   },
+			   'priority': -1,
+			   'layer': '',
+			   'content': {},
+			   'children': [
+				{
+					'id': 'bad0',
+					'priority': 0,
+					'enable': {
+						'start': 0
+					},
+					'layer': 'layer1',
+					'classes': [
+						'some_class'
+					],
+					'content': {}
+				}
+			   ],
+			   'isGroup': true
+			}
+		]
+
+		const options: ResolveOptions = {
+			time: 1500
+		}
+		// Resolve the timeline
+		const resolvedTimeline = Resolver.resolveTimeline(timeline, options)
+
+		// Calculate the state at a certain time:
+		const state0 = Resolver.getState(resolvedTimeline, 1500)
+
+		expect(state0.layers['layer1']).toBeTruthy()
+		expect(state0.layers['layer1'].id).toEqual('o5')
+		expect(state0.layers['layer0']).toBeTruthy()
+		expect(state0.layers['layer0'].id).toEqual('o1')
+
+	})
 })

--- a/src/__tests__/lib.spec.ts
+++ b/src/__tests__/lib.spec.ts
@@ -73,7 +73,7 @@ describe('lib', () => {
 			{ id: '%a', start: 10, end: 50, references: ['a'], caps: [{ id: 'p0', start: 0, end: 75 }] },
 			{ id: '%b', start: 20, end: 30, references: ['b'], caps: [{ id: 'p1', start: 0, end: 75 }] }
 		], true)).toEqual([
-			{ id: '%a', start: 10, end: 50, references: ['a', 'b'], caps: [{ id: 'p0', start: 0, end: 75 }, { id: 'p1', start: 0, end: 75 }] }
+			{ id: '%a', start: 10, end: 50, references: ['a', 'b'], caps: [{ id: 'p0', start: 0, end: 75 }] }
 		])
 
 		expect(cleanInstances([

--- a/src/__tests__/lib.spec.ts
+++ b/src/__tests__/lib.spec.ts
@@ -183,6 +183,14 @@ describe('lib', () => {
 			{ id: '@d', start: 1172, end: 1184, references: [ '@2', 'a0', 'a1' ] }
 		])
 	})
+	test('cleanInstances 2', () => {
+		expect(cleanInstances([
+			{ id: '%a', start: 1, end: null, references: ['a'] },
+			{ id: '%b', start: 500, end: 1000, references: ['b'], caps: [{ id: 'p0', start: 500, end: 1000 }] }
+		], true, true)).toEqual([
+			{ id: '%a', start: 1, end: null, references: ['a', 'b'] }
+		])
+	})
 	test('convertEventsToInstances', () => {
 		expect(convertEventsToInstances([
 			{

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -190,7 +190,7 @@ export function convertEventsToInstances (
 				// resume previous instance:
 				lastInstance.end = null
 				lastInstance.references = joinReferences(lastInstance.references, event.references)
-				lastInstance.caps = joinCaps(lastInstance.caps, event.data.instance.caps)
+				addCapsToResuming(lastInstance, event.data.instance.caps)
 			} else if (
 				!lastInstance ||
 				lastInstance.end !== null
@@ -208,7 +208,7 @@ export function convertEventsToInstances (
 			} else {
 				// There is already a running instance
 				lastInstance.references = joinReferences(lastInstance.references, event.references)
-				lastInstance.caps = joinCaps(lastInstance.caps, event.data.instance.caps)
+				addCapsToResuming(lastInstance, event.data.instance.caps)
 			}
 			if (lastInstance && lastInstance.caps && !lastInstance.caps.length) delete lastInstance.caps
 		} else {
@@ -531,6 +531,25 @@ export function joinReferences (...references: Array<Array<string> | string>): A
 		if (a < b) return -1
 		return 0
 	})
+}
+export function addCapsToResuming (instance: TimelineObjectInstance, ...caps: Array<Array<Cap> | undefined>): void {
+
+	const capsToAdd: Cap[] = []
+	_.each(joinCaps(...caps), (cap) => {
+
+		if (
+			cap.end &&
+			instance.end &&
+			cap.end > instance.end
+		) {
+			capsToAdd.push({
+				id: cap.id,
+				start: 0,
+				end: cap.end
+			})
+		}
+	})
+	instance.caps = joinCaps(instance.caps, capsToAdd)
 }
 export function joinCaps (...caps: Array<Array<Cap> | undefined>): Array<Cap> {
 	return (

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -216,7 +216,7 @@ export function resolveTimelineObj (resolvedTimeline: ResolvedTimeline, obj: Res
 				events.push({
 					time: instance.start,
 					value: true,
-					data: { instance: instance, id: 'a' + iStart++ },
+					data: { instance: instance, id: obj.id + '_' + iStart++ },
 					references: instance.references
 				})
 			})
@@ -224,7 +224,7 @@ export function resolveTimelineObj (resolvedTimeline: ResolvedTimeline, obj: Res
 			events.push({
 				time: lookedupStarts.value,
 				value: true,
-				data: { instance: { id: getId(), start: lookedupStarts.value, end: null, references:  lookedupStarts.references }, id: 'a' + iStart++ },
+				data: { instance: { id: getId(), start: lookedupStarts.value, end: null, references:  lookedupStarts.references }, id: obj.id + '_' + iStart++ },
 				references: lookedupStarts.references
 			})
 		}
@@ -245,7 +245,7 @@ export function resolveTimelineObj (resolvedTimeline: ResolvedTimeline, obj: Res
 					events.push({
 						time: instance.start,
 						value: false,
-						data: { instance: instance, id: 'a' + iEnd++ },
+						data: { instance: instance, id: obj.id + '_' + iEnd++ },
 						references: instance.references
 					})
 				})
@@ -253,7 +253,7 @@ export function resolveTimelineObj (resolvedTimeline: ResolvedTimeline, obj: Res
 				events.push({
 					time: lookedupEnds.value,
 					value: false,
-					data: { instance: { id: getId(), start: lookedupEnds.value, end: null, references: lookedupEnds.references }, id: 'a' + iEnd++ },
+					data: { instance: { id: getId(), start: lookedupEnds.value, end: null, references: lookedupEnds.references }, id: obj.id + '_' + iEnd++ },
 					references: lookedupEnds.references
 				})
 			}
@@ -367,7 +367,6 @@ export function lookupExpression (
 	context: ObjectRefType
 ): Array<TimelineObjectInstance> | ValueWithReference | null {
 	if (expr === null) return null
-
 	if (
 		_.isString(expr) &&
 		isNumeric(expr)


### PR DESCRIPTION
This case is showing a bad state computation.
layer0 is not getting an object, despite it (o1) enabling on the class which is made active by o5.
Removing the bad0 object, or changing the class it defines produces the correct result. As bad0 is not active in the state, it should not have any effect