### PR TITLE
Feature/resolve states

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,15 +71,17 @@ const options = {
 };
 const resolvedTimeline = Timeline.Resolver.resolveTimeline(myTimeline, options);
 
+// Use the resolved timeline and pre-calculate states, instance collisions, etc.
+const resolvedStates = Timeline.Resolver.resolveAllStates(resolvedTimeline);
 
 // Fetch the state at time 10:
-const state0 = Timeline.Resolver.getState(resolvedTimeline, 10);
+const state0 = Timeline.Resolver.getState(resolvedStates, 10);
 console.log(`At the time ${state0.time}, the active objects are "${
 	_.map(state0.layers, (o, l) => `${o.id} at layer ${l}`).join(', ')
 }"`);
 
 // Fetch the state at time 25:
-const state1 = Timeline.Resolver.getState(resolvedTimeline, 25);
+const state1 = Timeline.Resolver.getState(resolvedStates, 25);
 console.log(`At the time ${state1.time}, the active objects are "${
 	_.map(state1.layers, (o, l) => `${o.id} at layer ${l}`).join(', ')
 }"`);

--- a/examples/simple.js
+++ b/examples/simple.js
@@ -48,13 +48,15 @@ const options = {
     time: 0
 };
 const resolvedTimeline = Timeline.Resolver.resolveTimeline(myTimeline, options);
+// Use the resolved timeline and pre-calculate states, instance collisions, etc..
+const resolvedStates = Timeline.Resolver.resolveAllStates(resolvedTimeline);
 // Fetch the state at time 10:
-const state0 = Timeline.Resolver.getState(resolvedTimeline, 10);
+const state0 = Timeline.Resolver.getState(resolvedStates, 10);
 console.log(`At the time ${state0.time}, the active objects are "${_.map(state0.layers, (o, l) => `${o.id} at layer ${l}`).join(', ')}"`);
 // Fetch the state at time 25:
-const state1 = Timeline.Resolver.getState(resolvedTimeline, 25);
+const state1 = Timeline.Resolver.getState(resolvedStates, 25);
 console.log(`At the time ${state1.time}, the active objects are "${_.map(state1.layers, (o, l) => `${o.id} at layer ${l}`).join(', ')}"`);
-console.log(`The object "graphicBackground" will play at [${_.map(resolvedTimeline.objects['graphicBackground'].resolved.instances, (instance) => `${instance.start} to ${instance.end}`).join(', ')}]`);
+console.log(`The object "graphicBackground" will play at [${_.map(resolvedStates.objects['graphicBackground'].resolved.instances, (instance) => `${instance.start} to ${instance.end}`).join(', ')}]`);
 const nextEvent = state1.nextEvents[0];
 console.log(`After the time ${state1.time}, the next event to happen will be at time ${nextEvent.time}. The event is related to the object "${nextEvent.objId}"`);
 // Output:

--- a/examples/simple.ts
+++ b/examples/simple.ts
@@ -49,16 +49,19 @@ const options: Timeline.ResolveOptions = {
 }
 const resolvedTimeline = Timeline.Resolver.resolveTimeline(myTimeline, options)
 
+// Use the resolved timeline and pre-calculate states, instance collisions, etc..
+const resolvedStates = Timeline.Resolver.resolveAllStates(resolvedTimeline)
+
 // Fetch the state at time 10:
-const state0 = Timeline.Resolver.getState(resolvedTimeline, 10)
+const state0 = Timeline.Resolver.getState(resolvedStates, 10)
 console.log(`At the time ${state0.time}, the active objects are "${ _.map(state0.layers, (o, l) => `${ o.id } at layer ${l}`).join(', ') }"`)
 
 // Fetch the state at time 25:
-const state1 = Timeline.Resolver.getState(resolvedTimeline, 25)
+const state1 = Timeline.Resolver.getState(resolvedStates, 25)
 console.log(`At the time ${state1.time}, the active objects are "${ _.map(state1.layers, (o, l) => `${ o.id } at layer ${l}`).join(', ') }"`)
 
 console.log(`The object "graphicBackground" will play at [${
-	_.map(resolvedTimeline.objects['graphicBackground'].resolved.instances, (instance) => `${ instance.start } to ${instance.end}`).join(', ')
+	_.map(resolvedStates.objects['graphicBackground'].resolved.instances, (instance) => `${ instance.start } to ${instance.end}`).join(', ')
 }]`)
 
 const nextEvent = state1.nextEvents[0]

--- a/package.json
+++ b/package.json
@@ -97,6 +97,9 @@
     "typedoc": "^0.14.2",
     "typescript": "^3.3.3333"
   },
+  "resolutions": {
+    "typedoc/**/marked": "^0.6.2"
+  },
   "keywords": [
     "broadcast",
     "typescript",

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -6,6 +6,7 @@ import {
 	validateObject,
 	validateTimeline
 } from '../index'
+import * as _ from 'underscore'
 
 describe('index', () => {
 	test('resolve timeline', () => {
@@ -50,8 +51,10 @@ describe('index', () => {
 		// Resolve the timeline
 		const resolvedTimeline = Resolver.resolveTimeline(timeline, options)
 
+		const resolvedStates = Resolver.resolveAllStates(resolvedTimeline)
+
 		// Calculate the state at a certain time:
-		const state0 = Resolver.getState(resolvedTimeline, 15)
+		const state0 = Resolver.getState(resolvedStates, 15)
 
 		expect(state0).toMatchObject({
 			layers: {
@@ -160,5 +163,107 @@ describe('index', () => {
 		expect(state1.layers[0].content.attr3).toEqual(1)
 		expect(state2.layers[0].content.attr3).toEqual(undefined)
 
+	})
+	test('Resolve all states', () => {
+		const timeline: Array<TimelineObject> = [
+			{
+				id: 'video0',
+				layer: '0',
+				enable: {
+					start: 0,
+					end: 100
+				},
+				content: {},
+				priority: 5
+			},
+			{
+				id: 'video1',
+				layer: '0',
+				enable: {
+					start: 50,
+					end: 70
+				},
+				content: {},
+				priority: 5
+			},
+			{
+				id: 'video2',
+				layer: '0',
+				enable: {
+					start: 65,
+					end: 75
+				},
+				content: {},
+				priority: 5
+			},
+			{
+				id: 'video3',
+				layer: '0',
+				enable: {
+					start: 50,
+					end: 120
+				},
+				content: {},
+				priority: 3 // lower prio
+			}
+		]
+
+		const options: ResolveOptions = {
+			time: 0
+		}
+		// Resolve the timeline
+		const resolvedTimeline = Resolver.resolveTimeline(timeline, options)
+
+		const resolvedStates = Resolver.resolveAllStates(resolvedTimeline)
+
+		// Calculate the state at a certain time:
+		const state0 = Resolver.getState(resolvedStates, 20)
+		const state1 = Resolver.getState(resolvedStates, 60)
+		const state2 = Resolver.getState(resolvedStates, 65)
+		const state3 = Resolver.getState(resolvedStates, 80)
+		const state4 = Resolver.getState(resolvedStates, 110)
+
+		const state0a = Resolver.getState(resolvedTimeline, 20)
+		const state1a = Resolver.getState(resolvedTimeline, 60)
+		const state2a = Resolver.getState(resolvedTimeline, 65)
+		const state3a = Resolver.getState(resolvedTimeline, 80)
+		const state4a = Resolver.getState(resolvedTimeline, 110)
+
+		_.each(state0.layers, (obj, layer) => { expect(obj.id).toEqual(state0a.layers[layer].id) })
+		_.each(state1.layers, (obj, layer) => { expect(obj.id).toEqual(state1a.layers[layer].id) })
+		_.each(state2.layers, (obj, layer) => { expect(obj.id).toEqual(state2a.layers[layer].id) })
+		_.each(state3.layers, (obj, layer) => { expect(obj.id).toEqual(state3a.layers[layer].id) })
+		_.each(state4.layers, (obj, layer) => { expect(obj.id).toEqual(state4a.layers[layer].id) })
+
+		expect(state0.layers[0].id).toEqual('video0')
+		expect(state1.layers[0].id).toEqual('video1')
+		expect(state2.layers[0].id).toEqual('video2')
+		expect(state3.layers[0].id).toEqual('video0')
+		expect(state4.layers[0].id).toEqual('video3')
+
+		expect(resolvedStates.objects['video0'].resolved.instances).toHaveLength(2)
+		expect(resolvedStates.objects['video1'].resolved.instances).toHaveLength(1)
+		expect(resolvedStates.objects['video2'].resolved.instances).toHaveLength(1)
+
+		expect(resolvedStates.objects['video0'].resolved.instances[0]).toMatchObject({
+			start: 0,
+			end: 50
+		})
+		expect(resolvedStates.objects['video1'].resolved.instances[0]).toMatchObject({
+			start: 50,
+			end: 65
+		})
+		expect(resolvedStates.objects['video2'].resolved.instances[0]).toMatchObject({
+			start: 65,
+			end: 75
+		})
+		expect(resolvedStates.objects['video0'].resolved.instances[1]).toMatchObject({
+			start: 75,
+			end: 100
+		})
+		expect(resolvedStates.objects['video3'].resolved.instances[0]).toMatchObject({
+			start: 100,
+			end: 120
+		})
 	})
 })

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -21,6 +21,8 @@ export interface ResolveOptions {
 	limitCount?: number
 	/** Limits the repeating objects to a time in the future */
 	limitTime?: Time
+	/** If set to true, the resolver will go through the instances of the objects and fix collisions, so that the instances more closely resembles the end state. */
+	resolveInstanceCollisions?: boolean
 }
 export interface TimelineObject {
 	id: ObjectId
@@ -157,10 +159,12 @@ export interface ResolvedExpressionObj {
 	r: ResolvedExpression
 }
 export interface TimelineState {
-	time: Time,
-	layers: {
-		[layer: string]: ResolvedTimelineObjectInstance
-	},
+	time: Time
+	layers: StateInTime
+	nextEvents: Array<NextEvent>
+}
+export interface ResolvedStates extends ResolvedTimeline {
+	state: AllStates
 	nextEvents: Array<NextEvent>
 }
 export interface ResolvedTimelineObjectInstance extends ResolvedTimelineObject {
@@ -170,4 +174,21 @@ export interface NextEvent {
 	type: EventType
 	time: Time
 	objId: string
+}
+export interface ResolvedTimelineObjectInstanceKeyframe extends ResolvedTimelineObjectInstance {
+	isKeyframe?: boolean
+	keyframeEndTime?: TimeMaybe
+}
+export interface AllStates {
+	[layer: string]: {
+		[time: string]: ResolvedTimelineObjectInstanceKeyframe[] | null
+	}
+}
+export interface StateInTime {
+	[layer: string]: ResolvedTimelineObjectInstance
+}
+export interface TimeEvent {
+	time: number
+	/** true when the event indicate that something starts, false when something ends */
+	enable: boolean
 }

--- a/src/resolver/__tests__/resolver.spec.ts
+++ b/src/resolver/__tests__/resolver.spec.ts
@@ -320,7 +320,9 @@ describe('resolver', () => {
 			}
 		]
 
-		const resolved = Resolver.resolveTimeline(timeline, { time: 0 })
+		const resolved = Resolver.resolveAllStates(
+			Resolver.resolveTimeline(timeline, { time: 0 })
+		)
 
 		expect(resolved.objects['video']).toBeTruthy()
 		expect(resolved.objects['graphic0']).toBeTruthy()
@@ -432,7 +434,9 @@ describe('resolver', () => {
 			}
 		]
 
-		const resolved = Resolver.resolveTimeline(timeline, { time: 0, limitCount: 99, limitTime: 145 })
+		const resolved = Resolver.resolveAllStates(
+			Resolver.resolveTimeline(timeline, { time: 0, limitCount: 99, limitTime: 145 })
+		)
 
 		expect(resolved.statistics.resolvedObjectCount).toEqual(2)
 		expect(resolved.statistics.unresolvedCount).toEqual(0)
@@ -687,7 +691,7 @@ describe('resolver', () => {
 			}
 		]
 
-		const resolved = Resolver.resolveTimeline(timeline, { time: 0, limitTime: 50 })
+		const resolved = Resolver.resolveAllStates(Resolver.resolveTimeline(timeline, { time: 0, limitTime: 50 }))
 
 		expect(resolved.statistics.resolvedObjectCount).toEqual(2)
 		expect(resolved.statistics.resolvedKeyframeCount).toEqual(2)
@@ -706,8 +710,8 @@ describe('resolver', () => {
 			start: 20,
 			end: 25
 		}])
-
-		expect(Resolver.getState(resolved, 11)).toMatchObject({
+		const state0 = Resolver.getState(resolved, 11)
+		expect(state0).toMatchObject({
 			layers: {
 				'1': {
 					id: 'graphic0',
@@ -1050,7 +1054,7 @@ describe('resolver', () => {
 			}
 		]
 
-		const resolved = Resolver.resolveTimeline(timeline, { time: 0 })
+		const resolved = Resolver.resolveAllStates(Resolver.resolveTimeline(timeline, { time: 0 }))
 
 		expect(resolved.statistics.resolvedObjectCount).toEqual(4)
 		expect(resolved.statistics.unresolvedCount).toEqual(0)
@@ -1062,7 +1066,7 @@ describe('resolver', () => {
 
 		expect(resolved.objects['group0'].resolved).toMatchObject({
 			resolved: true,
-			instances: [{ start: 10, end: 100 }]
+			instances: [{ start: 10, end: 50 }] // because group 1 started
 		})
 		expect(resolved.objects['child0'].resolved).toMatchObject({
 			resolved: true,
@@ -1087,11 +1091,11 @@ describe('resolver', () => {
 				}
 			},
 			nextEvents: [
+				{ objId: 'group0', time: 50, type: EventType.END },
 				{ objId: 'group1', time: 50, type: EventType.START },
 				{ objId: 'child1', time: 55, type: EventType.START },
 				{ objId: 'child0', time: 100, type: EventType.END },
 				{ objId: 'child1', time: 100, type: EventType.END },
-				{ objId: 'group0', time: 100, type: EventType.END },
 				{ objId: 'group1', time: 100, type: EventType.END }
 			]
 		})
@@ -1107,7 +1111,6 @@ describe('resolver', () => {
 			nextEvents: [
 				{ objId: 'child0', time: 100, type: EventType.END },
 				{ objId: 'child1', time: 100, type: EventType.END },
-				{ objId: 'group0', time: 100, type: EventType.END },
 				{ objId: 'group1', time: 100, type: EventType.END }
 			]
 		})

--- a/src/resolver/common.ts
+++ b/src/resolver/common.ts
@@ -1,0 +1,19 @@
+import { ResolvedTimeline, ResolvedTimelineObject } from '../api/api'
+import * as _ from 'underscore'
+
+export function addObjectToResolvedTimeline (resolvedTimeline: ResolvedTimeline, obj: ResolvedTimelineObject) {
+	resolvedTimeline.objects[obj.id] = obj
+
+	if (obj.classes) {
+		_.each(obj.classes, (className: string) => {
+			if (className) {
+				if (!resolvedTimeline.classes[className]) resolvedTimeline.classes[className] = []
+				resolvedTimeline.classes[className].push(obj.id)
+			}
+		})
+	}
+	if (obj.layer) {
+		if (!resolvedTimeline.layers[obj.layer]) resolvedTimeline.layers[obj.layer] = []
+		resolvedTimeline.layers[obj.layer].push(obj.id)
+	}
+}

--- a/src/resolver/state.ts
+++ b/src/resolver/state.ts
@@ -5,128 +5,124 @@ import {
 	ResolvedTimelineObject,
 	TimelineObjectInstance,
 	ResolvedTimelineObjectInstance,
-	Content
+	Content,
+	AllStates,
+	StateInTime,
+	TimeEvent,
+	ResolvedStates,
+	ResolvedTimelineObjectInstanceKeyframe,
+	NextEvent
 } from '../api/api'
 import * as _ from 'underscore'
+import { addObjectToResolvedTimeline } from './common'
 import { EventType } from '../api/enums'
-import { extendMandadory } from '../lib'
 
-export function getState (resolved: ResolvedTimeline, time: Time, eventLimit: number = 0): TimelineState {
+export function getState (resolved: ResolvedTimeline | ResolvedStates, time: Time, eventLimit: number = 0): TimelineState {
+	const resolvedStates: ResolvedStates = (
+		isResolvedStates(resolved) ?
+		resolved :
+		resolveStates(resolved, time)
+	)
+
 	const state: TimelineState = {
 		time: time,
 		layers: {},
+		nextEvents: _.filter(resolvedStates.nextEvents, e => e.time > time)
+	}
+	if (eventLimit) state.nextEvents = state.nextEvents.slice(0, eventLimit)
+
+	_.each(_.keys(resolvedStates.layers), (layer: string) => {
+		const o = getStateAtTime(resolvedStates.state, layer, time)
+		if (o) state.layers[layer] = o
+	})
+
+	return state
+}
+export function resolveStates (resolved: ResolvedTimeline, onlyForTime?: Time): ResolvedStates {
+
+	const resolvedStates: ResolvedStates = {
+		options: resolved.options,
+		statistics: resolved.statistics,
+
+		// These will be re-created during the state-resolving:
+		objects: {},
+		classes: {},
+		layers: {},
+
+		state: {},
 		nextEvents: []
 	}
-	if (!resolved.objects) throw new Error('getState: input data missing .objects attribute')
 
 	const resolvedObjects = _.values(resolved.objects)
-
 	// Sort to make sure parent groups are evaluated before their children:
 	resolvedObjects.sort((a, b) => {
 		if ((a.resolved.levelDeep || 0) > (b.resolved.levelDeep || 0)) return 1
 		if ((a.resolved.levelDeep || 0) < (b.resolved.levelDeep || 0)) return -1
+
+		if (a.id > a.id) return 1
+		if (a.id < a.id) return -1
+
 		return 0
 	})
-	const activeObjIds: {[id: string]: ResolvedTimelineObjectInstance} = {}
+
+	// Step 1: Collect all points-of-interest (which points in time we want to evaluate)
+	// and which instances that are interesting
+	const pointsInTime: {
+		[time: string]: Array<{
+			obj: ResolvedTimelineObject,
+			instance: TimelineObjectInstance,
+			 /** if the instance turns on or off at this point */
+			enable: boolean
+		}>
+	} = {}
 	const eventObjectTimes: {[time: string]: EventType} = {}
+
 	_.each(resolvedObjects, (obj: ResolvedTimelineObject) => {
 		if (
 			!obj.disabled &&
 			obj.resolved.resolved &&
 			!obj.resolved.isKeyframe
 		) {
-			_.each(obj.resolved.instances, (instance: TimelineObjectInstance) => {
+			const parentTimes = getTimesFromParents(resolved, obj)
+			if (obj.layer) { // if layer is empty, don't put in state
+				_.each(obj.resolved.instances, (instance: TimelineObjectInstance) => {
 
-				if (obj.layer) { // if layer is empty, don't put in state
-					if (
-						// object instance is active:
-						(
-							instance.end === null ||
-							instance.end > time
-						) &&
-						instance.start <= time
-					) {
-
-						const parentObj = (
-							obj.resolved.parentId ?
-							resolved.objects[obj.resolved.parentId] :
-							null
+					let useInstance: boolean = true
+					if (onlyForTime) {
+						useInstance = (
+							(instance.start || 0) <= onlyForTime &&
+							(instance.end || Infinity) > onlyForTime
 						)
-						// If object has a parent, only set if parent is on layer (if layer is set for parent)
-						if (
-							!obj.resolved.parentId ||
-							(
-								parentObj &&
-								(
-									!parentObj.layer ||
-									activeObjIds[parentObj.id]
+					}
+					if (useInstance) {
+						const timeEvents: Array<TimeEvent> = []
+
+						timeEvents.push({ time: instance.start, enable: true })
+						if (instance.end) timeEvents.push({ time: instance.end, enable: false })
+
+						// Also include times from parents, as they could affect the state of this instance:
+						_.each(parentTimes, (parentTime) => {
+							if (
+								parentTime && (
+									parentTime.time > (instance.start || 0) &&
+									parentTime.time < (instance.end || Infinity)
 								)
-							)
-						) {
-							const clone: ResolvedTimelineObjectInstance = extendMandadory<ResolvedTimelineObject, ResolvedTimelineObjectInstance>(_.clone(obj),{
-								instance: _.clone(instance)
-							})
-							clone.content = JSON.parse(JSON.stringify(clone.content))
-							let setObj: boolean = false
-							const existingObj = state.layers[obj.layer]
-							if (!existingObj) {
-								setObj = true
-							} else {
-								// Priority:
-								if (
-									(
-										(obj.priority || 0) > (existingObj.priority || 0) 		// obj has higher priority => replaces existingObj
-									) || (
-										(obj.priority || 0) === (existingObj.priority || 0) &&
-										(instance.start || 0) > (existingObj.instance.start || 0)	// obj starts later => replaces existingObj
-									)
-								) {
-									setObj = true
-								}
+							) {
+								timeEvents.push(parentTime)
 							}
-							if (setObj) {
-								if (existingObj) {
-									// replace object on layer:
-									delete activeObjIds[existingObj.id]
-								}
-								state.layers[obj.layer] = clone
-								activeObjIds[clone.id] = clone
-							}
-						}
-					}
-					if (instance.start > time) {
-
-						state.nextEvents.push({
-							type: EventType.START,
-							time: instance.start,
-							objId: obj.id
 						})
-						eventObjectTimes['' + instance.start] = EventType.START
-					}
-					if (
-						instance.end !== null &&
-						instance.end > time
-					) {
-						state.nextEvents.push({
-							type: EventType.END,
-							time: instance.end,
-							objId: obj.id
+						// Save a reference to this instance on all points in time that could affect it:
+						_.each(timeEvents, (timeEvent) => {
+							if (!pointsInTime[timeEvent.time + '']) pointsInTime[timeEvent.time + ''] = []
+							pointsInTime[timeEvent.time + ''].push({ obj, instance, enable: timeEvent.enable })
 						})
-						eventObjectTimes['' + instance.end] = EventType.END
 					}
-				}
-
-			})
+				})
+			}
 		}
 	})
-
-	// _.each(state.layers, (obj) => {
-	// 	activeObjIds[obj.id] = obj
-	// })
-
-	// Keyframes:
-	const keyframes: ResolvedTimelineObjectInstance[] = []
-	_.each(resolved.objects, (obj: ResolvedTimelineObject) => {
+	// Also add keyframes to pointsInTime:
+	_.each(resolvedObjects, (obj: ResolvedTimelineObject) => {
 		if (
 			!obj.disabled &&
 			obj.resolved.resolved &&
@@ -134,76 +130,290 @@ export function getState (resolved: ResolvedTimeline, time: Time, eventLimit: nu
 			obj.resolved.parentId
 		) {
 			_.each(obj.resolved.instances, (instance: TimelineObjectInstance) => {
-				const kf: ResolvedTimelineObjectInstance = extendMandadory<ResolvedTimelineObject, ResolvedTimelineObjectInstance>(obj,{
-					instance: instance
-				})
-				keyframes.push(kf)
 
-				if (
-					instance.start > time &&
-					// tslint:disable-next-line
-					eventObjectTimes['' + instance.start] === undefined // no need to put a keyframe event if there's already another event
-				) {
-					state.nextEvents.push({
-						type: EventType.KEYFRAME,
-						time: instance.start,
-						objId: obj.id
-					})
-					eventObjectTimes['' + instance.start] = EventType.KEYFRAME
+				const timeEvents: Array<TimeEvent> = []
+
+				if (instance.start) {
+					timeEvents.push({ time: instance.start, enable: true })
+				} else {
+					timeEvents.push({ time: instance.start, enable: true })
 				}
-				if (
-					instance.end !== null &&
-					instance.end > time &&
-					// tslint:disable-next-line
-					eventObjectTimes['' + instance.end] === undefined // no need to put a keyframe event if there's already another event
-				) {
-					state.nextEvents.push({
-						type: EventType.KEYFRAME,
-						time: instance.end,
-						objId: obj.id
-					})
-					eventObjectTimes['' + instance.end] = EventType.KEYFRAME
-				}
+
+				_.each(timeEvents, (timeEvent) => {
+					if (!pointsInTime[timeEvent.time + '']) pointsInTime[timeEvent.time + ''] = []
+					pointsInTime[timeEvent.time + ''].push({ obj, instance, enable: timeEvent.enable })
+				})
 			})
 		}
 	})
-	keyframes.sort((a,b) => {
-		if (a.instance.start > b.instance.start) return 1
-		if (a.instance.start < b.instance.start) return -1
 
-		if (a.id > b.id) return -1
-		if (a.id < b.id) return 1
+	// Step 2: Resolve the state for the points-of-interest
+	// This is done by sweeping the points-of-interest chronologically,
+	// determining the state for every point in time by adding & removing objects from aspiringInstances
+	// Then sorting it to determine who takes precedence
 
-		return 0
+	const currentState: StateInTime = {}
+	const activeObjIds: {[id: string]: ResolvedTimelineObjectInstance} = {}
+
+	/** The objects in aspiringInstances  */
+	const aspiringInstances: {[layer: string]: Array<{obj: ResolvedTimelineObject, instance: TimelineObjectInstance}>} = {}
+
+	const keyframeEvents: NextEvent[] = []
+
+	const times: number[] = _.map(_.keys(pointsInTime), time => parseFloat(time))
+	// Sort chronologically:
+	times.sort((a,b) => {
+		return a - b
 	})
-	_.each(keyframes, (keyframe: ResolvedTimelineObjectInstance) => {
+	_.each(times, time => {
+		const instancesToCheck = pointsInTime[time]
+		const checkedObjectsThisTime: {[instanceId: string]: true} = {}
 
-		if (keyframe.resolved.parentId) {
-			const parentObj = activeObjIds[keyframe.resolved.parentId]
-			if (parentObj) {  // keyframe is on an active object
+		instancesToCheck.sort((a, b) => {
 
-				if (
-					// keyframe instance is active:
-					(
-						keyframe.instance.end === null ||
-						keyframe.instance.end > time
-					) &&
-					keyframe.instance.start <= time &&
-					// keyframe is within the keyframe.instance of its parent:
-					keyframe.instance.start >= parentObj.instance.start &&
-					(
-						parentObj.instance.end === null ||
-						keyframe.instance.start < parentObj.instance.end
+			if (a.obj.resolved && b.obj.resolved) {
+
+				// Keyframes comes last:
+				if (a.obj.resolved.isKeyframe && !b.obj.resolved.isKeyframe) return 1
+				if (!a.obj.resolved.isKeyframe && b.obj.resolved.isKeyframe) return -1
+
+				// Ending events come before starting events:
+				if (a.enable && !b.enable) return 1
+				if (!a.enable && b.enable) return -1
+
+				// Deeper objects (children in groups) comes later, we want to check the parent groups first:
+				if ((a.obj.resolved.levelDeep || 0) > (b.obj.resolved.levelDeep || 0)) return 1
+				if ((a.obj.resolved.levelDeep || 0) < (b.obj.resolved.levelDeep || 0)) return -1
+
+			}
+
+			return 0
+		})
+
+		_.each(instancesToCheck, (o) => {
+			const obj: ResolvedTimelineObject = o.obj
+			const instance: TimelineObjectInstance = o.instance
+
+			let toBeEnabled: boolean = (
+				(instance.start || 0) <= time &&
+				(instance.end || Infinity) > time
+			)
+
+			const layer: string = obj.layer + ''
+
+			if (!checkedObjectsThisTime[obj.id + '_' + instance.id + '_' + o.enable]) { // Only check each object and event-type once for every point in time
+				checkedObjectsThisTime[obj.id + '_' + instance.id + '_' + o.enable] = true
+
+				if (!obj.resolved.isKeyframe) {
+
+					// If object has a parent, only set if parent is on a layer (if layer is set for parent)
+					if (toBeEnabled && obj.resolved.parentId) {
+						const parentObj = (
+							obj.resolved.parentId ?
+							resolved.objects[obj.resolved.parentId] :
+							null
+						)
+						toBeEnabled = !!(
+							parentObj &&
+							(
+								!parentObj.layer ||
+								activeObjIds[parentObj.id]
+							)
+						)
+					}
+					if (!aspiringInstances[obj.layer]) aspiringInstances[obj.layer] = []
+					if (toBeEnabled) {
+						// The instance wants to be enabled (is starting)
+
+						// Add to aspiringInstances:
+						aspiringInstances[obj.layer].push({ obj, instance })
+
+					} else {
+						// The instance doesn't want to be enabled (is ending)
+
+						// Remove from aspiringInstances:
+						aspiringInstances[layer] = _.reject(aspiringInstances[layer] || [], o => o.obj.id === obj.id)
+					}
+
+					// Evaluate the layer to determine who has the throne:
+					aspiringInstances[layer].sort((a, b) => {
+						// Determine who takes precedence:
+
+						// First, sort using priority
+						if ((a.obj.priority || 0) < (b.obj.priority || 0)) return 1
+						if ((a.obj.priority || 0) > (b.obj.priority || 0)) return -1
+
+						// Then, sort using the start time
+						if ((a.instance.start || 0) < (b.instance.start || 0)) return 1
+						if ((a.instance.start || 0) > (b.instance.start || 0)) return -1
+
+						// Last resort: sort using id:
+						if (a.obj.id > b.obj.id) return 1
+						if (a.obj.id < b.obj.id) return -1
+
+						return 0
+					})
+
+					// Now, the one on top has the throne
+					// Update current state:
+					const currentOnTopOfLayer = aspiringInstances[layer][0]
+					const prevObj = currentState[layer]
+
+					const replaceOldObj: boolean = (
+						currentOnTopOfLayer &&
+						(
+							!prevObj ||
+							prevObj.id !== currentOnTopOfLayer.obj.id ||
+							prevObj.instance.id !== currentOnTopOfLayer.instance.id
+						)
 					)
-				) {
+					const removeOldObj: boolean = (
+						!currentOnTopOfLayer &&
+						prevObj
+					)
 
-					applyKeyframeContent(parentObj.content, keyframe.content)
+					if (replaceOldObj || removeOldObj) {
+						if (prevObj) {
+							// Cap the old instance, so it'll end at this point in time:
+							prevObj.instance.end = time
+
+							// Update activeObjIds:
+							delete activeObjIds[prevObj.id]
+
+							// Add to nextEvents:
+							if (
+								prevObj.instance.end !== null && (
+									!onlyForTime ||
+									prevObj.instance.end > onlyForTime
+								)
+							) {
+								resolvedStates.nextEvents.push({
+									type: EventType.END,
+									time: prevObj.instance.end,
+									objId: prevObj.id
+								})
+								eventObjectTimes[instance.end + ''] = EventType.END
+							}
+						}
+					}
+					if (replaceOldObj) {
+						// Set the new object to State
+
+						// Construct a new object clone:
+						let newObj: ResolvedTimelineObject
+						if (resolvedStates.objects[currentOnTopOfLayer.obj.id]) {
+							// Use the already existing one
+							newObj = resolvedStates.objects[currentOnTopOfLayer.obj.id]
+						} else {
+							newObj = _.clone(currentOnTopOfLayer.obj)
+							newObj.content = JSON.parse(JSON.stringify(newObj.content))
+							newObj.resolved = {
+								...newObj.resolved || {},
+								instances: []
+							}
+
+							addObjectToResolvedTimeline(resolvedStates, newObj)
+						}
+
+						const newInstance = {
+							...currentOnTopOfLayer.instance,
+							// We're setting new start & end times so they match up with the state:
+							start: time,
+							end: null
+						}
+						newObj.resolved.instances.push(newInstance)
+
+						const newObjInstance = {
+							...newObj,
+							instance: newInstance
+						}
+
+						// Save to current state:
+						currentState[layer] = newObjInstance
+
+						// Update activeObjIds:
+						activeObjIds[newObjInstance.id] = newObjInstance
+
+						// Update the tracking state as well:
+						setStateAtTime(resolvedStates.state, layer, time, newObjInstance)
+
+						// Add to nextEvents:
+						if (newInstance.start > (onlyForTime || 0)) {
+							resolvedStates.nextEvents.push({
+								type: EventType.START,
+								time: newInstance.start,
+								objId: obj.id
+							})
+							eventObjectTimes[newInstance.start + ''] = EventType.START
+						}
+					} else if (removeOldObj) {
+
+						// Remove from current state:
+						delete currentState[layer]
+
+						// Update the tracking state as well:
+						setStateAtTime(resolvedStates.state, layer, time, null)
+					}
+				} else {
+					// Is a keyframe
+					const keyframe = obj
+
+					// Add keyframe to resolvedStates.objects:
+					resolvedStates.objects[keyframe.id] = keyframe
+
+					// Check if the keyframe's parent is currently active?
+					if (keyframe.resolved.parentId) {
+						const parentObj = activeObjIds[keyframe.resolved.parentId]
+						if (parentObj && parentObj.layer) {  // keyframe is on an active object
+
+							const parentObjInstance = currentState[parentObj.layer]
+
+							if (parentObjInstance) {
+
+								const keyframeInstance: ResolvedTimelineObjectInstanceKeyframe = {
+									...keyframe,
+									instance: instance,
+									isKeyframe: true,
+									keyframeEndTime: instance.end
+								}
+								// Note: The keyframes are a little bit special, since their contents are applied to their parents.
+								// That application is done in the getStateAtTime function.
+
+								// Add keyframe to the tracking state:
+								addKeyframeAtTime(resolvedStates.state, parentObj.layer + '', time, keyframeInstance)
+
+								// Add keyframe to nextEvents:
+								keyframeEvents.push({
+									type: EventType.KEYFRAME,
+									time: instance.start,
+									objId: keyframe.id
+								})
+								if (instance.end !== null) {
+									keyframeEvents.push({
+										type: EventType.KEYFRAME,
+										time: instance.end,
+										objId: keyframe.id
+									})
+								}
+							}
+						}
+					}
 				}
 			}
+		})
+	})
+	// Go through the keyframe events and add them to nextEvents:
+	_.each(keyframeEvents, (keyframeEvent) => {
+		if (eventObjectTimes[keyframeEvent.time + ''] === undefined) { // no need to put a keyframe event if there's already another event there
+			resolvedStates.nextEvents.push(keyframeEvent)
+			eventObjectTimes[keyframeEvent.time + ''] = EventType.KEYFRAME
 		}
 	})
 
-	state.nextEvents.sort((a,b) => {
+	if (onlyForTime) {
+		resolvedStates.nextEvents = _.filter(resolvedStates.nextEvents, e => e.time > onlyForTime)
+	}
+	resolvedStates.nextEvents.sort((a,b) => {
 		if (a.time > b.time) return 1
 		if (a.time < b.time) return -1
 
@@ -216,9 +426,7 @@ export function getState (resolved: ResolvedTimeline, time: Time, eventLimit: nu
 		return 0
 	})
 
-	if (eventLimit > 0 && state.nextEvents.length > eventLimit) state.nextEvents.splice(eventLimit) // delete the rest
-
-	return state
+	return resolvedStates
 }
 export function applyKeyframeContent (parentContent: Content, keyframeContent: Content) {
 	_.each(keyframeContent, (value: any, attr: string) => {
@@ -236,4 +444,93 @@ export function applyKeyframeContent (parentContent: Content, keyframeContent: C
 			parentContent[attr] = value
 		}
 	})
+}
+function getTimesFromParents (resolved: ResolvedTimeline, obj: ResolvedTimelineObject): TimeEvent[] {
+	let times: TimeEvent[] = []
+	const parentObj = (
+		obj.resolved.parentId ?
+		resolved.objects[obj.resolved.parentId] :
+		null
+	)
+	if (parentObj && parentObj.resolved.resolved) {
+		_.each(parentObj.resolved.instances, instance => {
+			times.push({ time: instance.start, enable: true })
+			if (instance.end) times.push({ time: instance.end, enable: false })
+		})
+		times = times.concat(getTimesFromParents(resolved, parentObj))
+	}
+	return times
+}
+
+function setStateAtTime (states: AllStates, layer: string, time: number, objInstance: ResolvedTimelineObjectInstanceKeyframe | null) {
+	if (!states[layer]) states[layer] = {}
+	states[layer][time + ''] = objInstance ? [objInstance] : objInstance
+}
+function addKeyframeAtTime (states: AllStates, layer: string, time: number, objInstanceKf: ResolvedTimelineObjectInstanceKeyframe) {
+	if (!states[layer]) states[layer] = {}
+
+	if (!states[layer][time + '']) states[layer][time + ''] = []
+	// @ts-ignore object is possibly null
+	states[layer][time + ''].push(objInstanceKf)
+}
+function getStateAtTime (states: AllStates, layer: string, requestTime: number) {
+	const layerStates = states[layer] || {}
+
+	const times: number[] = _.map(_.keys(layerStates), time => parseFloat(time))
+	times.sort((a,b) => {
+		return a - b
+	})
+	let state: ResolvedTimelineObjectInstance | null = null
+	let isCloned: boolean = false
+	_.find(times, (time) => {
+		if (time <= requestTime) {
+			const currentStateInstances = layerStates[time + '']
+			if (currentStateInstances && currentStateInstances.length) {
+
+				_.each(currentStateInstances, currentState => {
+					if (
+						currentState &&
+						currentState.isKeyframe
+					) {
+						const keyframe = currentState
+						if (state && keyframe.resolved.parentId === state.id) {
+							if (
+								(keyframe.keyframeEndTime || Infinity) > requestTime
+							) {
+								if (!isCloned) {
+									isCloned = true
+									state = {
+										...state,
+										content: JSON.parse(JSON.stringify(state.content))
+									}
+								}
+								// Apply the keyframe on the state:
+								applyKeyframeContent(state.content, keyframe.content)
+							}
+						}
+					} else {
+						state = currentState
+						isCloned = false
+					}
+				})
+			} else {
+				state = null
+				isCloned = false
+			}
+
+			return false
+		} else {
+			return true
+		}
+	})
+	return state
+}
+function isResolvedStates (resolved: any): resolved is ResolvedStates {
+	return !!(
+		resolved &&
+		typeof resolved === 'object' &&
+		resolved.objects &&
+		resolved.state &&
+		resolved.nextEvents
+	)
 }

--- a/src/resolver/state.ts
+++ b/src/resolver/state.ts
@@ -282,10 +282,8 @@ export function resolveStates (resolved: ResolvedTimeline, onlyForTime?: Time): 
 
 							// Add to nextEvents:
 							if (
-								prevObj.instance.end !== null && (
-									!onlyForTime ||
-									prevObj.instance.end > onlyForTime
-								)
+								!onlyForTime ||
+								prevObj.instance.end > onlyForTime
 							) {
 								resolvedStates.nextEvents.push({
 									type: EventType.END,
@@ -404,6 +402,7 @@ export function resolveStates (resolved: ResolvedTimeline, onlyForTime?: Time): 
 	})
 	// Go through the keyframe events and add them to nextEvents:
 	_.each(keyframeEvents, (keyframeEvent) => {
+		// tslint:disable-next-line
 		if (eventObjectTimes[keyframeEvent.time + ''] === undefined) { // no need to put a keyframe event if there's already another event there
 			resolvedStates.nextEvents.push(keyframeEvent)
 			eventObjectTimes[keyframeEvent.time + ''] = EventType.KEYFRAME

--- a/yarn.lock
+++ b/yarn.lock
@@ -2183,9 +2183,9 @@ growly@^1.3.0:
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
 handlebars@*, handlebars@^4.0.2, handlebars@^4.0.6, handlebars@^4.1.0:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.1.tgz#6e4e41c18ebe7719ae4d38e5aca3d32fa3dd23d3"
-  integrity sha512-3Zhi6C0euYZL5sM0Zcy7lInLXKQ+YLcF/olbN010mzGQ4XVm50JeyBnMqofHh696GrciGruC7kCcApPDJvVgwA==
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
+  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -3415,10 +3415,10 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-marked@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.4.0.tgz#9ad2c2a7a1791f10a852e0112f77b571dce10c66"
-  integrity sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==
+marked@^0.4.0, marked@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.6.2.tgz#c574be8b545a8b48641456ca1dbe0e37b6dccc1a"
+  integrity sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==
 
 mem@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
This PR adds a new resolve step: `Resolver.resolveAllStates()`, which replaces much of the functionality in the old `Resolver.getState()`

Instead of just calculating the state for a certain time, `Resolver.resolveAllStates()` sweeps through the time and calculates all the states and stores them in an intermediate datastructure `ResolvedStates`, which is then fed to `Resolver.getState()` in order to calculate the state as we had it before.

The biggest reason to do this is to get accurate instances, so when an instance is interrupted by another on the same layer, it'll now have the proper start & end times (before, the instances where overlapping in time).