### PR TITLE
fix: some expressions failing to be converted to objects

### DIFF
--- a/src/resolver/__tests__/expression.spec.ts
+++ b/src/resolver/__tests__/expression.spec.ts
@@ -98,6 +98,26 @@ describe('Expression', () => {
 				}
 			}
 		})
+
+		expect(interpretExpression('(!.classA | !$layer.classB) & #obj')).toMatchObject({
+			'l': {
+				'l': {
+					'l': '',
+					'o': '!',
+					'r': '.classA'
+				},
+				'o': '|',
+				'r': {
+					'l': '',
+					'o': '!',
+					'r': '$layer.classB'
+				}
+			},
+			'o': '&',
+			'r': '#obj'
+		})
+
+		expect(interpretExpression('#obj.start')).toEqual('#obj.start')
 	})
 	test('wrapInnerExpressions', () => {
 		expect(wrapInnerExpressions(

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -4,7 +4,6 @@ import {
 	ResolvedTimeline,
 	ResolveOptions,
 	Expression,
-	ExpressionObj,
 	ResolvedTimelineObject,
 	TimelineObjectInstance,
 	Time,
@@ -163,7 +162,7 @@ export function resolveTimelineObj (resolvedTimeline: ResolvedTimeline, obj: Res
 		start = 'false'
 	}
 
-	const startExpr: ExpressionObj | number | null = interpretExpression(start)
+	const startExpr: Expression = interpretExpression(start)
 	let parentInstances: TimelineObjectInstance[] | null | ValueWithReference = null
 	let hasParent: boolean = false
 	let referToParent: boolean = false
@@ -230,7 +229,7 @@ export function resolveTimelineObj (resolvedTimeline: ResolvedTimeline, obj: Res
 		}
 
 		if (obj.enable.end !== undefined) {
-			const endExpr: ExpressionObj | number | null = interpretExpression(obj.enable.end)
+			const endExpr: Expression = interpretExpression(obj.enable.end)
 			// lookedupEnds will contain an inverted list of instances. Therefore .start means an end
 			let lookedupEnds = (
 				endExpr ?
@@ -258,7 +257,7 @@ export function resolveTimelineObj (resolvedTimeline: ResolvedTimeline, obj: Res
 				})
 			}
 		} else if (obj.enable.duration !== undefined) {
-			const durationExpr: ExpressionObj | number | null = interpretExpression(obj.enable.duration)
+			const durationExpr: Expression = interpretExpression(obj.enable.duration)
 			let lookedupDuration = lookupExpression(resolvedTimeline, obj, durationExpr, 'duration')
 
 			if (_.isArray(lookedupDuration) && lookedupDuration.length === 1) {


### PR DESCRIPTION
Fixes expressions where nested single item arrays get produced.

Update the typings of interpretExpression as it can also return a string if the input was a single reference.

Improve the error reporting of validateExpression