### PR TITLE
Circular dependency if enabler references own layer or class

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -119,6 +119,8 @@ export interface ResolvedTimelineObject extends TimelineObject {
 		parentId?: string
 		/** True if object is a keyframe */
 		isKeyframe?: boolean
+		/** True if object is referencing itself (only directly, not indirectly via another object) */
+		isSelfReferencing?: boolean
 	}
 }
 export interface TimelineObjectInstance {

--- a/src/resolver/__tests__/resolver.spec.ts
+++ b/src/resolver/__tests__/resolver.spec.ts
@@ -1432,4 +1432,74 @@ describe('resolver', () => {
 			originalEnd: 240
 		})
 	})
+	test('Reference own layer', () => {
+		const timeline: TimelineObject[] = [
+			{
+				id: 'video0',
+				layer: '0',
+				enable: {
+					start: 0,
+					duration: 8,
+					repeating: 10
+				},
+				content: {}
+			},
+			{
+				id: 'video1',
+				layer: '0',
+				enable: {
+					// Play for 2 after each other object on layer '0'
+					start: '$0.end',
+					duration: 2
+				},
+				content: {}
+			}
+		]
+
+		const resolved = Resolver.resolveAllStates(Resolver.resolveTimeline(timeline, { time: 0, limitCount: 100, limitTime: 99999 }))
+
+		expect(resolved.statistics.resolvedObjectCount).toEqual(2)
+		expect(resolved.statistics.unresolvedCount).toEqual(0)
+
+		expect(resolved.objects['video0']).toBeTruthy()
+		expect(resolved.objects['video0'].resolved.instances).toHaveLength(100)
+		expect(resolved.objects['video1']).toBeTruthy()
+		expect(resolved.objects['video1'].resolved.instances).toHaveLength(100)
+	})
+	test('Reference own class', () => {
+		const timeline: TimelineObject[] = [
+			{
+				id: 'video0',
+				layer: '0',
+				enable: {
+					start: 0,
+					duration: 8,
+					repeating: 10
+				},
+				content: {},
+				classes: [ 'insert_after' ]
+			},
+			{
+				id: 'video1',
+				layer: '1',
+				enable: {
+					// Play for 2 after each other object with class 'insert_after'
+					start: '.insert_after.end',
+					duration: 2
+				},
+				content: {},
+				classes: [ 'insert_after' ]
+			}
+		]
+
+		const resolved = Resolver.resolveAllStates(Resolver.resolveTimeline(timeline, { time: 0, limitCount: 100, limitTime: 99999 }))
+
+		expect(resolved.statistics.resolvedObjectCount).toEqual(2)
+		expect(resolved.statistics.unresolvedCount).toEqual(0)
+
+		expect(resolved.objects['video0']).toBeTruthy()
+		expect(resolved.objects['video0'].resolved.instances).toHaveLength(100)
+		expect(resolved.objects['video1']).toBeTruthy()
+		expect(resolved.objects['video1'].resolved.instances).toHaveLength(100)
+	})
 })

--- a/src/resolver/__tests__/resolver.spec.ts
+++ b/src/resolver/__tests__/resolver.spec.ts
@@ -1,5 +1,5 @@
 import { lookupExpression, Resolver } from '../resolver'
-import { ResolvedTimeline, TimelineObject } from '../../api/api'
+import { ResolvedTimeline, TimelineObject, ResolvedTimelineObject } from '../../api/api'
 import { interpretExpression } from '../expression'
 import { EventType } from '../../api/enums'
 import { resetId } from '../../lib'
@@ -25,11 +25,16 @@ describe('resolver', () => {
 			resolvedKeyframeCount: 0
 		}
 	}
-	const stdObj: TimelineObject = {
+	const stdObj: ResolvedTimelineObject = {
 		id: 'obj0',
 		layer: '10',
 		enable: {},
-		content: {}
+		content: {},
+		resolved: {
+			resolved: false,
+			resolving: false,
+			instances: []
+		}
 	}
 	test('expression: basic math', () => {
 		expect(lookupExpression(rtl, stdObj, interpretExpression('1+2'), 'start'))		.toEqual({ value: 1 + 2, references: [] })
@@ -238,11 +243,16 @@ describe('resolver', () => {
 			classes: {},
 			layers: {}
 		}
-		const obj: TimelineObject = {
+		const obj: ResolvedTimelineObject = {
 			id: 'obj0',
 			layer: '10',
 			enable: {},
-			content: {}
+			content: {},
+			resolved: {
+				resolved: false,
+				resolving: false,
+				instances: []
+			}
 		}
 
 		expect(lookupExpression(rtl, obj, interpretExpression('#unknown'), 'start')).toEqual(null)
@@ -1480,12 +1490,14 @@ describe('resolver', () => {
 				end: 8
 			}])
 			expect(resolved.objects['video1']).toBeTruthy()
+			expect(resolved.objects['video1'].resolved.isSelfReferencing).toEqual(true)
 			expect(resolved.objects['video1'].resolved.instances).toMatchObject([{
 				start: 8,
 				end: 9, // becuse it's overridden by video2
 				originalEnd: 10
 			}])
 			expect(resolved.objects['video2']).toBeTruthy()
+			expect(resolved.objects['video2'].resolved.isSelfReferencing).toEqual(true)
 			expect(resolved.objects['video2'].resolved.instances).toMatchObject([{
 				start: 9,
 				end: 11
@@ -1543,12 +1555,14 @@ describe('resolver', () => {
 				end: 8
 			}])
 			expect(resolved.objects['video1']).toBeTruthy()
+			expect(resolved.objects['video1'].resolved.isSelfReferencing).toEqual(true)
 			expect(resolved.objects['video1'].resolved.instances).toMatchObject([{
 				start: 8,
 				end: 9, // becuse it's overridden by video2
 				originalEnd: 10
 			}])
 			expect(resolved.objects['video2']).toBeTruthy()
+			expect(resolved.objects['video2'].resolved.isSelfReferencing).toEqual(true)
 			expect(resolved.objects['video2'].resolved.instances).toMatchObject([{
 				start: 9,
 				end: 11


### PR DESCRIPTION
* **What is the current behavior?** (You can also link to an open issue here)
Circular dependency exception is thrown, causing the timeline resolve to fail

* **What is the expected behavior?**
As they are very loose selectors, it would be preferable if they could simply ignore the object initiating it.

This behaviour would be useful to be able to insert an object after each other object on a layer. Such as to insert a static titlecard or endcard for a video

* **Other information**:
