### PR TITLE
chore: test for keyframe enabler with a negate

### DIFF
--- a/src/__tests__/legacy.spec.ts
+++ b/src/__tests__/legacy.spec.ts
@@ -1968,7 +1968,7 @@ const testDataOld: {
 			'id': 'head_force_clear',
 			'trigger': {
 				'type': TriggerType.LOGICAL,
-				'value': '!$Lnora_primary_super.nora_super_is_clear'
+				'value': '!$nora_primary_super.nora_super_is_clear'
 			},
 			'priority': 20,
 			'duration': 0,
@@ -2017,7 +2017,7 @@ const testDataOld: {
 			'id': 'head_force_clear',
 			'trigger': {
 				'type': TriggerType.LOGICAL,
-				'value': '!$Lnora_primary_super.nora_super_is_clear'
+				'value': '!$nora_primary_super.nora_super_is_clear'
 			},
 			'priority': 20,
 			'duration': 0,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -449,6 +449,11 @@ export function applyRepeatingInstances (
 	})
 	return cleanInstances(repeatedInstances, false)
 }
+/**
+ * Cap instances so that they are within their parentInstances
+ * @param instances
+ * @param parentInstances
+ */
 export function capInstances (
 	instances: TimelineObjectInstance[],
 	parentInstances: ValueWithReference | TimelineObjectInstance[] | null

--- a/src/resolver/__tests__/resolver.spec.ts
+++ b/src/resolver/__tests__/resolver.spec.ts
@@ -1432,4 +1432,114 @@ describe('resolver', () => {
 			originalEnd: 240
 		})
 	})
+	test('Keyframe falsey enable', () => {
+		const timeline: TimelineObject[] = [
+			{
+				id: 'video0',
+				layer: '0',
+				enable: {
+					while: 1
+				},
+				content: {
+					val: 1
+				},
+				keyframes: [
+					{
+						id: 'keyframe0',
+						enable: { while: '!.class0' },
+						content: {
+							val2: 2
+						}
+					}
+				]
+			},
+			{
+				id: 'enabler0',
+				layer: '1',
+				enable: {
+					start: 100
+				},
+				content: {},
+				classes: ['class0']
+			}
+		]
+
+		const resolved = Resolver.resolveAllStates(Resolver.resolveTimeline(timeline, { time: 0, limitCount: 10, limitTime: 999 }))
+
+		expect(resolved.statistics.resolvedObjectCount).toEqual(2)
+		expect(resolved.statistics.unresolvedCount).toEqual(0)
+
+		expect(resolved.objects['video0']).toBeTruthy()
+		expect(resolved.objects['video0'].resolved.instances).toHaveLength(1)
+
+		// Before class
+		const state = Resolver.getState(resolved, 10, 10)
+		expect(state.layers['0']).toBeTruthy()
+		expect(state.layers['0'].content).toEqual({
+			val: 1,
+			val2: 2
+		})
+
+		// With class
+		const state2 = Resolver.getState(resolved, 110, 10)
+		expect(state2.layers['0']).toBeTruthy()
+		expect(state2.layers['0'].content).toEqual({
+			val: 1
+		})
+	})
+	test('Keyframe truthy enable', () => {
+		const timeline: TimelineObject[] = [
+			{
+				id: 'video0',
+				layer: '0',
+				enable: {
+					while: 1
+				},
+				content: {
+					val: 1
+				},
+				keyframes: [
+					{
+						id: 'keyframe0',
+						enable: { while: '.class0' },
+						content: {
+							val2: 2
+						}
+					}
+				]
+			},
+			{
+				id: 'enabler0',
+				layer: '1',
+				enable: {
+					start: 100
+				},
+				content: {},
+				classes: ['class0']
+			}
+		]
+
+		const resolved = Resolver.resolveAllStates(Resolver.resolveTimeline(timeline, { time: 0, limitCount: 10, limitTime: 999 }))
+
+		expect(resolved.statistics.resolvedObjectCount).toEqual(2)
+		expect(resolved.statistics.unresolvedCount).toEqual(0)
+
+		expect(resolved.objects['video0']).toBeTruthy()
+		expect(resolved.objects['video0'].resolved.instances).toHaveLength(1)
+
+		// Before class
+		const state = Resolver.getState(resolved, 10, 10)
+		expect(state.layers['0']).toBeTruthy()
+		expect(state.layers['0'].content).toEqual({
+			val: 1
+		})
+
+		// With class
+		const state2 = Resolver.getState(resolved, 110, 10)
+		expect(state2.layers['0']).toBeTruthy()
+		expect(state2.layers['0'].content).toEqual({
+			val: 1,
+			val2: 2
+		})
+	})
 })

--- a/src/resolver/__tests__/resolver.spec.ts
+++ b/src/resolver/__tests__/resolver.spec.ts
@@ -1597,4 +1597,29 @@ describe('resolver', () => {
 			val2: 2
 		})
 	})
+	test('Class not defined', () => {
+		const timeline: TimelineObject[] = [
+			{
+				id: 'video0',
+				layer: '0',
+				priority: 0,
+				enable: {
+					while: '!.class0'
+				},
+				content: {}
+			}
+		]
+
+		const resolved = Resolver.resolveAllStates(Resolver.resolveTimeline(timeline, { time: 0, limitCount: 10, limitTime: 999 }))
+
+		expect(resolved.statistics.resolvedObjectCount).toEqual(1)
+		expect(resolved.statistics.unresolvedCount).toEqual(0)
+
+		expect(resolved.objects['video0']).toBeTruthy() // TODO - is this one correct?
+		expect(resolved.objects['video0'].resolved.instances).toHaveLength(1)
+
+		const state = Resolver.getState(resolved, 10, 10)
+		expect(state.layers['0']).toBeTruthy()
+		expect(state.layers['0'].id).toEqual('video0')
+	})
 })

--- a/src/resolver/__tests__/resolver.spec.ts
+++ b/src/resolver/__tests__/resolver.spec.ts
@@ -144,7 +144,7 @@ describe('resolver', () => {
 			lookupExpression(rtl, stdObj,
 				interpretExpression('14 + #badReference.start'), 'start'
 			)
-		).toEqual(null)
+		).toEqual([])
 
 		expect(
 			lookupExpression(rtl, stdObj, interpretExpression('1'), 'start')
@@ -245,7 +245,7 @@ describe('resolver', () => {
 			content: {}
 		}
 
-		expect(lookupExpression(rtl, obj, interpretExpression('#unknown'), 'start')).toEqual(null)
+		expect(lookupExpression(rtl, obj, interpretExpression('#unknown'), 'start')).toEqual([])
 		expect(lookupExpression(rtl, obj, interpretExpression('#first'), 'start')).toMatchObject([{
 			start: 0,
 			end: 100

--- a/src/resolver/__tests__/resolver.spec.ts
+++ b/src/resolver/__tests__/resolver.spec.ts
@@ -1504,7 +1504,7 @@ describe('resolver', () => {
 				id: 'video0',
 				layer: '0',
 				enable: {
-					while: 1
+					start: 1
 				},
 				content: {
 					val: 1

--- a/src/resolver/__tests__/resolver.spec.ts
+++ b/src/resolver/__tests__/resolver.spec.ts
@@ -1143,8 +1143,8 @@ describe('resolver', () => {
 				id: 'group0',
 				layer: 'g0',
 				enable: {
-					start: 0,
-					duration: 80,
+					start: 0, // 0, 100
+					duration: 80, // 80, 180
 					repeating: 100
 				},
 				content: {},
@@ -1154,8 +1154,8 @@ describe('resolver', () => {
 						id: 'child0',
 						layer: '1',
 						enable: {
-							start: '50', // 50
-							duration: 20 // 70
+							start: '50', // 50, 150
+							duration: 20 // 70, 170
 						},
 						content: {}
 					},
@@ -1163,8 +1163,8 @@ describe('resolver', () => {
 						id: 'child1',
 						layer: '2',
 						enable: {
-							start: '#child0.end', // 70
-							duration: 50 // 120, to be capped at 100
+							start: '#child0.end', // 70, 170
+							duration: 50 // 120 (to be capped at 100), 220 (to be capped at 200)
 						},
 						content: {}
 					}

--- a/src/resolver/__tests__/resolver.spec.ts
+++ b/src/resolver/__tests__/resolver.spec.ts
@@ -1487,6 +1487,61 @@ describe('resolver', () => {
 			val: 1
 		})
 	})
+	test('Keyframe falsey enable2', () => {
+		const timeline: TimelineObject[] = [
+			{
+				id: 'video0',
+				layer: '0',
+				enable: {
+					while: '1'
+				},
+				content: {
+					val: 1
+				},
+				keyframes: [
+					{
+						id: 'keyframe0',
+						enable: { while: '!.class0' },
+						content: {
+							val2: 2
+						}
+					}
+				]
+			},
+			{
+				id: 'enabler0',
+				layer: '1',
+				enable: {
+					start: 100
+				},
+				content: {},
+				classes: ['class0']
+			}
+		]
+
+		const resolved = Resolver.resolveAllStates(Resolver.resolveTimeline(timeline, { time: 0, limitCount: 10, limitTime: 999 }))
+
+		expect(resolved.statistics.resolvedObjectCount).toEqual(2)
+		expect(resolved.statistics.unresolvedCount).toEqual(0)
+
+		expect(resolved.objects['video0']).toBeTruthy()
+		expect(resolved.objects['video0'].resolved.instances).toHaveLength(1)
+
+		// Before class
+		const state = Resolver.getState(resolved, 10, 10)
+		expect(state.layers['0']).toBeTruthy()
+		expect(state.layers['0'].content).toEqual({
+			val: 1,
+			val2: 2
+		})
+
+		// With class
+		const state2 = Resolver.getState(resolved, 110, 10)
+		expect(state2.layers['0']).toBeTruthy()
+		expect(state2.layers['0'].content).toEqual({
+			val: 1
+		})
+	})
 	test('Keyframe truthy enable', () => {
 		const timeline: TimelineObject[] = [
 			{

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -156,9 +156,9 @@ export function resolveTimelineObj (resolvedTimeline: ResolvedTimeline, obj: Res
 			obj.enable.start :
 		''
 	)
-	if (obj.enable.while === '1') {
+	if (obj.enable.while + '' === '1') {
 		start = 'true'
-	} else if (obj.enable.while === '0') {
+	} else if (obj.enable.while + '' === '0') {
 		start = 'false'
 	}
 


### PR DESCRIPTION
A keyframe `enable: { while: '.class0' }` works, but `enable: { while: '!.class0' }` always ends up as unresolved.
This is always the case if the class referenced does not exist on the timeline, but if it does then that the behaviour can vary depending on  if the while on the parent object being either `1` or `'1'`.