### PR TITLE
Child referring parent

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -34,7 +34,7 @@ export function extendMandadory<A, B extends A> (original: A, extendObj: Differe
 	return _.extend(original, extendObj)
 }
 
-export function isConstant (str: string | number | null | any): boolean {
+export function isConstant (str: string | number | null | any): str is string | number {
 	return !!(
 		isNumeric(str) ||
 		(
@@ -46,7 +46,7 @@ export function isConstant (str: string | number | null | any): boolean {
 		)
 	)
 }
-export function isNumeric (str: string | number | null | any): boolean {
+export function isNumeric (str: string | number | null | any): str is string | number {
 	if (str === null) return false
 	if (_.isNumber(str)) return true
 	if (_.isString(str)) return !!(str.match(/^[\-\+]?[0-9\.]+$/) && !_.isNaN(parseFloat(str)))

--- a/src/resolver/__tests__/expression.spec.ts
+++ b/src/resolver/__tests__/expression.spec.ts
@@ -1,4 +1,4 @@
-import { interpretExpression, wrapInnerExpressions } from '../expression'
+import { interpretExpression, wrapInnerExpressions, simplifyExpression } from '../expression'
 
 describe('Expression', () => {
 	test('interpretExpression from string', () => {
@@ -133,6 +133,19 @@ describe('Expression', () => {
 			['a', '&', '!', 'b']
 		)).toEqual({rest: [], inner:
 			['a', '&', ['', '!', 'b']]
+		})
+	})
+	test('simplifyExpression', () => {
+		expect(simplifyExpression('1+2+3'
+		)).toEqual(6)
+
+		expect(simplifyExpression('1+2*2+(4-2)'
+		)).toEqual(7)
+
+		expect(simplifyExpression('40+2+asdf')).toEqual({
+			l: 42,
+			o: '+',
+			r: 'asdf'
 		})
 	})
 })

--- a/src/resolver/__tests__/resolver.spec.ts
+++ b/src/resolver/__tests__/resolver.spec.ts
@@ -1774,7 +1774,7 @@ describe('resolver', () => {
 
 		const resolved = Resolver.resolveAllStates(Resolver.resolveTimeline(timeline, { time: 0, limitCount: 10, limitTime: 999 }))
 
-		expect(resolved.statistics.resolvedObjectCount).toEqual(3)
+		expect(resolved.statistics.resolvedObjectCount).toEqual(4)
 
 		// All 3 videos should start at the same time:
 		expect(resolved.objects['video0']).toBeTruthy()

--- a/src/resolver/__tests__/resolver.spec.ts
+++ b/src/resolver/__tests__/resolver.spec.ts
@@ -1726,4 +1726,76 @@ describe('resolver', () => {
 			}
 		])
 	})
+	test('Parent references', () => {
+		const timeline: TimelineObject[] = [
+			{
+				id: 'parent',
+				layer: 'p0',
+				priority: 0,
+				enable: {
+					start: '100'
+				},
+				content: {},
+				isGroup: true,
+				children: [
+					{
+						id: 'video0',
+						layer: '0',
+						priority: 0,
+						enable: {
+							start: 20 + 30,
+							duration: 10
+						},
+						content: {}
+					},
+					{
+						id: 'video1',
+						layer: '1',
+						priority: 0,
+						enable: {
+							start: '20 + 30',
+							duration: 10
+						},
+						content: {}
+					}
+				]
+			},
+			{
+				id: 'video2',
+				layer: '2',
+				priority: 0,
+				enable: {
+					start: '150',
+					duration: 10
+				},
+				content: {}
+			}
+		]
+
+		const resolved = Resolver.resolveAllStates(Resolver.resolveTimeline(timeline, { time: 0, limitCount: 10, limitTime: 999 }))
+
+		expect(resolved.statistics.resolvedObjectCount).toEqual(3)
+
+		// All 3 videos should start at the same time:
+		expect(resolved.objects['video0']).toBeTruthy()
+		expect(resolved.objects['video1']).toBeTruthy()
+		expect(resolved.objects['video2']).toBeTruthy()
+		expect(resolved.objects['video0'].resolved.instances).toHaveLength(1)
+		expect(resolved.objects['video1'].resolved.instances).toHaveLength(1)
+		expect(resolved.objects['video2'].resolved.instances).toHaveLength(1)
+
+		expect(resolved.objects['video0'].resolved.instances[0]).toMatchObject({
+			start: 150,
+			end: 160
+		})
+		expect(resolved.objects['video1'].resolved.instances[0]).toMatchObject({
+			start: 150,
+			end: 160
+		})
+		expect(resolved.objects['video2'].resolved.instances[0]).toMatchObject({
+			start: 150,
+			end: 160
+		})
+
+	})
 })

--- a/src/resolver/expression.ts
+++ b/src/resolver/expression.ts
@@ -4,6 +4,10 @@ import { isNumeric } from '../lib'
 
 export const OPERATORS = ['&', '|', '+', '-', '*', '/', '%', '!']
 
+export function interpretExpression (expr: null): null
+export function interpretExpression (expr: number): number
+export function interpretExpression (expr: ExpressionObj): ExpressionObj
+export function interpretExpression (expr: string | Expression): Expression
 export function interpretExpression (expr: Expression): Expression {
 	if (isNumeric(expr)) {
 		return parseFloat(expr as string)

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -33,7 +33,7 @@ import {
 	resetId
 } from '../lib'
 import { validateTimeline } from './validate'
-import { interpretExpression } from './expression'
+import { interpretExpression, simplifyExpression } from './expression'
 import { getState, resolveStates } from './state'
 import { addObjectToResolvedTimeline } from './common'
 
@@ -162,7 +162,8 @@ export function resolveTimelineObj (resolvedTimeline: ResolvedTimeline, obj: Res
 		start = 'false'
 	}
 
-	const startExpr: Expression = interpretExpression(start)
+	const startExpr: Expression = simplifyExpression(start)
+
 	let parentInstances: TimelineObjectInstance[] | null = null
 	let hasParent: boolean = false
 	let referToParent: boolean = false


### PR DESCRIPTION
Credit goes to @jesperstarkar who found this bug.

It turns out that a child in a group that is
`enable: '1+1'`
is not equal to
`enable: '2'`