### PR TITLE
feat: be able to provide enable.instances directly in the timeline.

### DIFF
--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -387,12 +387,10 @@ describe('index', () => {
 			{
 				id: 'video',
 				layer: '0',
-				enable: {
-					instances: [
-						{ start: 10, end: 20 },
-						{ start: 30, end: 40 }
-					]
-				},
+				enable: [
+					{ start: 10, end: 20 },
+					{ start: 30, end: 40 }
+				],
 				content: {}
 			}
 		]

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -381,5 +381,46 @@ describe('index', () => {
 		expect(state0.layers['layer0']).toBeTruthy()
 		expect(state0.layers['layer0'].id).toEqual('o1')
 
- 	})
+	 })
+	 test('instances', () => {
+		const timeline: Array<TimelineObject> = [
+			{
+				id: 'video',
+				layer: '0',
+				enable: {
+					instances: [
+						{ start: 10, end: 20 },
+						{ start: 30, end: 40 }
+					]
+				},
+				content: {}
+			}
+		]
+		// First, just to a validation, to make sure it's okay:
+		validateTimeline(timeline, true)
+
+		const options: ResolveOptions = {
+			time: 0
+		}
+		// Resolve the timeline
+		const resolvedTimeline = Resolver.resolveTimeline(timeline, options)
+
+		const resolvedStates = Resolver.resolveAllStates(resolvedTimeline)
+
+		// Calculate the state at a certain time:
+		const state0 = Resolver.getState(resolvedStates, 5)
+		expect(state0.layers['0']).toBeFalsy()
+
+		const state1 = Resolver.getState(resolvedStates, 15)
+		expect(state1).toMatchObject({
+			layers: {
+				'0': { id: 'video' }
+			},
+			nextEvents: [
+				{ time: 20, type: EventType.END, objId: 'video' },
+				{ time: 30, type: EventType.START, objId: 'video' },
+				{ time: 40, type: EventType.END, objId: 'video' }
+			]
+		})
+	})
 })

--- a/src/__tests__/legacy.spec.ts
+++ b/src/__tests__/legacy.spec.ts
@@ -10,7 +10,8 @@ import {
 	ResolvedTimelineObject as NewResolvedTimelineObject,
 	TimelineObject as NewTimelineObject,
 	TimelineKeyframe as NewTimelineKeyframe,
-	ResolveOptions
+	ResolveOptions,
+	TimelineEnable
 } from '../api/api'
 import {
 	Resolver
@@ -2192,10 +2193,10 @@ const testData: {
 } = {}
 // Convert test-data to new data structure:
 function convertTimelineObject (obj: TimelineObject): NewTimelineObject {
+	const enable: TimelineEnable = {}
 	const newObj: NewTimelineObject = {
 		id: obj.id,
-		enable: {
-		},
+		enable: enable,
 		layer: obj.LLayer,
 		// children?: Array<TimelineObject>
 		// keyframes?: Array<TimelineKeyframe>
@@ -2207,19 +2208,19 @@ function convertTimelineObject (obj: TimelineObject): NewTimelineObject {
 	}
 
 	if (obj.trigger.type === TriggerType.TIME_ABSOLUTE) {
-		newObj.enable.start = obj.trigger.value
+		enable.start = obj.trigger.value
 	} else if (obj.trigger.type === TriggerType.TIME_RELATIVE) {
-		newObj.enable.start = obj.trigger.value
+		enable.start = obj.trigger.value
 	} else if (obj.trigger.type === TriggerType.LOGICAL) {
-		newObj.enable.while = obj.trigger.value
-		// if (newObj.enable.while === '1') {
-		// 	newObj.enable.while = 'true'
-		// } else if (newObj.enable.while === '0') {
-		// 	newObj.enable.while = 'false'
+		enable.while = obj.trigger.value
+		// if (enable.while === '1') {
+		// 	enable.while = 'true'
+		// } else if (enable.while === '0') {
+		// 	enable.while = 'false'
 		// }
 	}
 	if (obj.duration) {
-		newObj.enable.duration = obj.duration
+		enable.duration = obj.duration
 	}
 	// @ts-ignore
 	if (obj.legacyRepeatingTime) {
@@ -2251,10 +2252,10 @@ function convertTimelineObject (obj: TimelineObject): NewTimelineObject {
 	return newObj
 }
 function convertTimelineKeyframe (obj: TimelineKeyframe): NewTimelineKeyframe {
+	const enable: TimelineEnable = {}
 	const newKf: NewTimelineKeyframe = {
 		id: obj.id,
-		enable: {
-		},
+		enable: enable,
 		// children?: Array<TimelineObject>
 		// keyframes?: Array<TimelineKeyframe>
 		classes: obj.classes,
@@ -2262,14 +2263,14 @@ function convertTimelineKeyframe (obj: TimelineKeyframe): NewTimelineKeyframe {
 		content: obj.content as any
 	}
 	if (obj.trigger.type === TriggerType.TIME_ABSOLUTE) {
-		newKf.enable.start = obj.trigger.value
+		enable.start = obj.trigger.value
 	} else if (obj.trigger.type === TriggerType.TIME_RELATIVE) {
-		newKf.enable.start = obj.trigger.value
+		enable.start = obj.trigger.value
 	} else if (obj.trigger.type === TriggerType.LOGICAL) {
-		newKf.enable.while = obj.trigger.value
+		enable.while = obj.trigger.value
 	}
 	if (obj.duration) {
-		newKf.enable.duration = obj.duration
+		enable.duration = obj.duration
 	}
 	return newKf
 }
@@ -2917,6 +2918,7 @@ let tests: Tests = {
 		}).toThrowError()
 		expect(() => {
 			const data = clone(getTestData('basic'))
+			// @ts-ignore
 			delete data[0].enable.start
 			const tl = Resolver.resolveTimeline(data, stdOpts)
 			Resolver.getState(tl, now)
@@ -3501,6 +3503,7 @@ let tests: Tests = {
 		// expect(tl.statistics.resolvedObjectCount).toEqual(0)
 
 		const obj0: NewTimelineObject = _.findWhere(data, { id: 'obj0' }) as NewTimelineObject
+		// @ts-ignore
 		obj0.enable.duration = 10 // break the circular dependency
 
 		const tl = Resolver.resolveTimeline(data, stdOpts)

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -65,6 +65,8 @@ export interface TimelineEnable {
 	duration?: Expression
 	/** (Optional) Makes the object repeat with given interval */
 	repeating?: Expression
+	/** (Optional) Instead of anything above, define instances directly */
+	instances?: BasicInstance[]
 }
 export interface TimelineKeyframe {
 	id: string
@@ -123,16 +125,17 @@ export interface ResolvedTimelineObject extends TimelineObject {
 		isSelfReferencing?: boolean
 	}
 }
-export interface TimelineObjectInstance {
+export interface BasicInstance {
+	/** The start time of the instance */
+	start: Time
+	/** The end time of the instance (null = infinite) */
+	end: Time | null
+}
+export interface TimelineObjectInstance extends BasicInstance {
 	/** id of the instance (unique)  */
 	id: string
 	/** if true, the instance starts from the beginning of time */
 	isFirst?: boolean
-	/** The start time of the instance  */
-	start: Time
-	/** The end time of the instance (null = infinite) */
-	end: Time | null
-
 	/** The original start time of the instance (if an instance is split or capped, the original start time is retained in here).
 	 * If undefined, fallback to .start
 	 */

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -26,7 +26,7 @@ export interface ResolveOptions {
 }
 export interface TimelineObject {
 	id: ObjectId
-	enable: TimelineEnable
+	enable: TimelineEnable | TimelineEnable[]
 
 	layer: string | number
 	/** Group children */
@@ -65,12 +65,10 @@ export interface TimelineEnable {
 	duration?: Expression
 	/** (Optional) Makes the object repeat with given interval */
 	repeating?: Expression
-	/** (Optional) Instead of anything above, define instances directly */
-	instances?: BasicInstance[]
 }
 export interface TimelineKeyframe {
 	id: string
-	enable: TimelineEnable
+	enable: TimelineEnable | TimelineEnable[]
 	duration?: number | string
 	classes?: Array<string>
 	content: Content

--- a/src/resolver/__tests__/validate.spec.ts
+++ b/src/resolver/__tests__/validate.spec.ts
@@ -1,5 +1,5 @@
 import { validateObject, validateKeyframe, validateTimeline } from '../validate'
-import { TimelineObject, TimelineKeyframe } from '../../api/api'
+import { TimelineObject, TimelineKeyframe, TimelineEnable } from '../../api/api'
 import _ = require('underscore')
 
 describe('validate', () => {
@@ -72,7 +72,7 @@ describe('validate', () => {
 
 		expect(() => {
 			const o = _.clone(obj)
-			o.enable = _.clone(o.enable)
+			o.enable = _.clone(o.enable) as TimelineEnable
 			o.enable.while = 32
 			validateObject(o, true)
 		}).toThrowError()
@@ -192,7 +192,7 @@ describe('validate', () => {
 
 		expect(() => {
 			const o = _.clone(keyframe)
-			o.enable = _.clone(o.enable)
+			o.enable = _.clone(o.enable) as TimelineEnable
 			o.enable.while = 32
 			validateKeyframe(o, true)
 		}).toThrowError()
@@ -227,7 +227,7 @@ describe('validate', () => {
 
 		expect(() => {
 			const o = _.clone(keyframe)
-			o.enable = _.clone(o.enable)
+			o.enable = _.clone(o.enable) as TimelineEnable
 			delete o.enable.start
 			validateKeyframe(o, true)
 		}).toThrowError()

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -140,216 +140,228 @@ export function resolveTimelineObj (resolvedTimeline: ResolvedTimeline, obj: Res
 
 	let instances: Array<TimelineObjectInstance> = []
 
-	const repeatingExpr: Expression | null = (
-		obj.enable.repeating !== undefined ?
-		interpretExpression(obj.enable.repeating) :
-		null
-	)
-	const lookedupRepeating = lookupExpression(resolvedTimeline, obj, repeatingExpr, 'duration')
-	if (_.isArray(lookedupRepeating)) {
-		throw new Error(`lookupExpression should never return an array for .duration lookup`) // perhaps tmp? maybe revisit this at some point
-	}
-
-	let start: Expression = (
-		obj.enable.while !== undefined ?
-			obj.enable.while :
-		obj.enable.start !== undefined ?
-			obj.enable.start :
-		''
-	)
-	if (obj.enable.while + '' === '1') {
-		start = 'true'
-	} else if (obj.enable.while + '' === '0') {
-		start = 'false'
-	}
-
-	const startExpr: Expression = simplifyExpression(start)
-
-	let parentInstances: TimelineObjectInstance[] | null = null
-	let hasParent: boolean = false
-	let referToParent: boolean = false
-	if (obj.resolved.parentId) {
-		hasParent = true
-		parentInstances = lookupExpression(
-			resolvedTimeline,
-			obj,
-			interpretExpression(`#${obj.resolved.parentId}`),
-			'start'
-		) as TimelineObjectInstance[] | null // a start-reference will always return an array, or null
-
-		if (isConstant(startExpr)) {
-			// Only use parent if the expression resolves to a number (ie doesn't contain any references)
-			referToParent = true
-		}
-	}
-	let lookedupStarts = lookupExpression(resolvedTimeline, obj, startExpr, 'start')
-
-	const applyParentInstances = (value: TimelineObjectInstance[] | null | ValueWithReference): TimelineObjectInstance[] | null | ValueWithReference => {
-		const operate = (a: ValueWithReference | null, b: ValueWithReference | null): ValueWithReference | null => {
-			if (a === null || b === null) return null
-			return {
-				value: a.value + b.value,
-				references: joinReferences(a.references, b.references)
-			}
-		}
-		return operateOnArrays(parentInstances, value, operate)
-	}
-	if (referToParent) {
-		lookedupStarts = applyParentInstances(lookedupStarts)
-	}
-
-	if (obj.enable.while) {
-		if (_.isArray(lookedupStarts)) {
-			instances = lookedupStarts
-		} else if (lookedupStarts !== null) {
-			instances = [{
+	if (obj.enable.instances) {
+		_.each(obj.enable.instances, instance => {
+			instances.push({
 				id: getId(),
-				start: lookedupStarts.value,
-				end: null,
-				references: lookedupStarts.references
-			}]
-		}
+				start: instance.start,
+				end: instance.end,
+				references: []
+			})
+		})
 	} else {
-		const events: Array<EventForInstance> = []
-		let iStart: number = 0
-		let iEnd: number = 0
-		if (_.isArray(lookedupStarts)) {
-			_.each(lookedupStarts, (instance) => {
-				events.push({
-					time: instance.start,
-					value: true,
-					data: { instance: instance, id: obj.id + '_' + iStart++ },
-					references: instance.references
-				})
-			})
-		} else if (lookedupStarts !== null) {
-			events.push({
-				time: lookedupStarts.value,
-				value: true,
-				data: { instance: { id: getId(), start: lookedupStarts.value, end: null, references:  lookedupStarts.references }, id: obj.id + '_' + iStart++ },
-				references: lookedupStarts.references
-			})
+		const repeatingExpr: Expression | null = (
+			obj.enable.repeating !== undefined ?
+			interpretExpression(obj.enable.repeating) :
+			null
+		)
+		const lookedupRepeating = lookupExpression(resolvedTimeline, obj, repeatingExpr, 'duration')
+		if (_.isArray(lookedupRepeating)) {
+			throw new Error(`lookupExpression should never return an array for .duration lookup`) // perhaps tmp? maybe revisit this at some point
 		}
 
-		if (obj.enable.end !== undefined) {
-			const endExpr: Expression = interpretExpression(obj.enable.end)
-			// lookedupEnds will contain an inverted list of instances. Therefore .start means an end
-			let lookedupEnds = (
-				endExpr ?
-				lookupExpression(resolvedTimeline, obj, endExpr, 'end') :
-				null
-			)
-			if (referToParent && isConstant(endExpr)) {
-				lookedupEnds = applyParentInstances(lookedupEnds)
+		let start: Expression = (
+			obj.enable.while !== undefined ?
+				obj.enable.while :
+			obj.enable.start !== undefined ?
+				obj.enable.start :
+			''
+		)
+		if (obj.enable.while + '' === '1') {
+			start = 'true'
+		} else if (obj.enable.while + '' === '0') {
+			start = 'false'
+		}
+
+		const startExpr: Expression = simplifyExpression(start)
+
+		let parentInstances: TimelineObjectInstance[] | null = null
+		let hasParent: boolean = false
+		let referToParent: boolean = false
+		if (obj.resolved.parentId) {
+			hasParent = true
+			parentInstances = lookupExpression(
+				resolvedTimeline,
+				obj,
+				interpretExpression(`#${obj.resolved.parentId}`),
+				'start'
+			) as TimelineObjectInstance[] | null // a start-reference will always return an array, or null
+
+			if (isConstant(startExpr)) {
+				// Only use parent if the expression resolves to a number (ie doesn't contain any references)
+				referToParent = true
 			}
-			if (_.isArray(lookedupEnds)) {
-				_.each(lookedupEnds, (instance) => {
+		}
+		let lookedupStarts = lookupExpression(resolvedTimeline, obj, startExpr, 'start')
+
+		const applyParentInstances = (value: TimelineObjectInstance[] | null | ValueWithReference): TimelineObjectInstance[] | null | ValueWithReference => {
+			const operate = (a: ValueWithReference | null, b: ValueWithReference | null): ValueWithReference | null => {
+				if (a === null || b === null) return null
+				return {
+					value: a.value + b.value,
+					references: joinReferences(a.references, b.references)
+				}
+			}
+			return operateOnArrays(parentInstances, value, operate)
+		}
+		if (referToParent) {
+			lookedupStarts = applyParentInstances(lookedupStarts)
+		}
+
+		// if (obj.enable.instances) {
+
+		if (obj.enable.while) {
+			if (_.isArray(lookedupStarts)) {
+				instances = lookedupStarts
+			} else if (lookedupStarts !== null) {
+				instances = [{
+					id: getId(),
+					start: lookedupStarts.value,
+					end: null,
+					references: lookedupStarts.references
+				}]
+			}
+		} else {
+			const events: Array<EventForInstance> = []
+			let iStart: number = 0
+			let iEnd: number = 0
+			if (_.isArray(lookedupStarts)) {
+				_.each(lookedupStarts, (instance) => {
 					events.push({
 						time: instance.start,
-						value: false,
-						data: { instance: instance, id: obj.id + '_' + iEnd++ },
+						value: true,
+						data: { instance: instance, id: obj.id + '_' + iStart++ },
 						references: instance.references
 					})
 				})
-			} else if (lookedupEnds !== null) {
+			} else if (lookedupStarts !== null) {
 				events.push({
-					time: lookedupEnds.value,
-					value: false,
-					data: { instance: { id: getId(), start: lookedupEnds.value, end: null, references: lookedupEnds.references }, id: obj.id + '_' + iEnd++ },
-					references: lookedupEnds.references
+					time: lookedupStarts.value,
+					value: true,
+					data: { instance: { id: getId(), start: lookedupStarts.value, end: null, references:  lookedupStarts.references }, id: obj.id + '_' + iStart++ },
+					references: lookedupStarts.references
 				})
 			}
-		} else if (obj.enable.duration !== undefined) {
-			const durationExpr: Expression = interpretExpression(obj.enable.duration)
-			let lookedupDuration = lookupExpression(resolvedTimeline, obj, durationExpr, 'duration')
 
-			if (_.isArray(lookedupDuration) && lookedupDuration.length === 1) {
-				lookedupDuration = {
-					value: lookedupDuration[0].start,
-					references: lookedupDuration[0].references
-				} as ValueWithReference
-			}
-			if (_.isArray(lookedupDuration) && !lookedupDuration.length) lookedupDuration = null
-
-			if (_.isArray(lookedupDuration)) {
-				throw new Error(`lookupExpression should never return an array for .duration lookup`) // perhaps tmp? maybe revisit this at some point
-			} else if (lookedupDuration !== null) {
-
-				if (
-					lookedupRepeating !== null &&
-					lookedupDuration.value > lookedupRepeating.value
-				) lookedupDuration.value = lookedupRepeating.value
-
-				const tmpLookedupDuration: ValueWithReference = lookedupDuration // cast type
-				_.each(events, (e) => {
-					if (e.value) {
-						const time = e.time + tmpLookedupDuration.value
-						const references = joinReferences(e.references, tmpLookedupDuration.references)
+			if (obj.enable.end !== undefined) {
+				const endExpr: Expression = interpretExpression(obj.enable.end)
+				// lookedupEnds will contain an inverted list of instances. Therefore .start means an end
+				let lookedupEnds = (
+					endExpr ?
+					lookupExpression(resolvedTimeline, obj, endExpr, 'end') :
+					null
+				)
+				if (referToParent && isConstant(endExpr)) {
+					lookedupEnds = applyParentInstances(lookedupEnds)
+				}
+				if (_.isArray(lookedupEnds)) {
+					_.each(lookedupEnds, (instance) => {
 						events.push({
-							time: time,
+							time: instance.start,
 							value: false,
-							data: { id: e.data.id, instance: { id: e.data.instance.id, start: time, end: null, references: references } },
-							references: references
+							data: { instance: instance, id: obj.id + '_' + iEnd++ },
+							references: instance.references
 						})
-					}
-				})
-			}
-		}
+					})
+				} else if (lookedupEnds !== null) {
+					events.push({
+						time: lookedupEnds.value,
+						value: false,
+						data: { instance: { id: getId(), start: lookedupEnds.value, end: null, references: lookedupEnds.references }, id: obj.id + '_' + iEnd++ },
+						references: lookedupEnds.references
+					})
+				}
+			} else if (obj.enable.duration !== undefined) {
+				const durationExpr: Expression = interpretExpression(obj.enable.duration)
+				let lookedupDuration = lookupExpression(resolvedTimeline, obj, durationExpr, 'duration')
 
-		instances = convertEventsToInstances(events, false)
-	}
-	if (hasParent) {
-		// figure out what parent-instance the instances are tied to, and cap them
-		const cappedInstances: TimelineObjectInstance[] = []
-		_.each(instances, (instance) => {
-			if (parentInstances) {
+				if (_.isArray(lookedupDuration) && lookedupDuration.length === 1) {
+					lookedupDuration = {
+						value: lookedupDuration[0].start,
+						references: lookedupDuration[0].references
+					} as ValueWithReference
+				}
+				if (_.isArray(lookedupDuration) && !lookedupDuration.length) lookedupDuration = null
 
-				const parentInstance = _.find(parentInstances, (parentInstance) => {
-					return instance.references.indexOf(parentInstance.id) !== -1
-				})
+				if (_.isArray(lookedupDuration)) {
+					throw new Error(`lookupExpression should never return an array for .duration lookup`) // perhaps tmp? maybe revisit this at some point
+				} else if (lookedupDuration !== null) {
 
-				if (parentInstance) {
-					// If the child refers to its parent, there should be one specific instance to cap into
-					const cappedInstance = capInstances([instance], [parentInstance])[0]
+					if (
+						lookedupRepeating !== null &&
+						lookedupDuration.value > lookedupRepeating.value
+					) lookedupDuration.value = lookedupRepeating.value
 
-					if (cappedInstance) {
-
-						if (!cappedInstance.caps) cappedInstance.caps = []
-						cappedInstance.caps.push({
-							id: parentInstance.id,
-							start: parentInstance.start,
-							end: parentInstance.end
-						})
-						cappedInstances.push(cappedInstance)
-					}
-				} else {
-					// If the child doesn't refer to its parent, it should be capped within all of its parent instances
-					_.each(parentInstances, parentInstance => {
-
-						const cappedInstance = capInstances([instance], [parentInstance])[0]
-
-						if (cappedInstance) {
-							if (parentInstance) {
-								if (!cappedInstance.caps) cappedInstance.caps = []
-								cappedInstance.caps.push({
-									id: parentInstance.id,
-									start: parentInstance.start,
-									end: parentInstance.end
-								})
-							}
-							cappedInstances.push(cappedInstance)
+					const tmpLookedupDuration: ValueWithReference = lookedupDuration // cast type
+					_.each(events, (e) => {
+						if (e.value) {
+							const time = e.time + tmpLookedupDuration.value
+							const references = joinReferences(e.references, tmpLookedupDuration.references)
+							events.push({
+								time: time,
+								value: false,
+								data: { id: e.data.id, instance: { id: e.data.instance.id, start: time, end: null, references: references } },
+								references: references
+							})
 						}
 					})
 				}
 			}
-		})
-		instances = cappedInstances
+			instances = convertEventsToInstances(events, false)
+		}
+		if (hasParent) {
+			// figure out what parent-instance the instances are tied to, and cap them
+			const cappedInstances: TimelineObjectInstance[] = []
+			_.each(instances, (instance) => {
+				if (parentInstances) {
+
+					const parentInstance = _.find(parentInstances, (parentInstance) => {
+						return instance.references.indexOf(parentInstance.id) !== -1
+					})
+
+					if (parentInstance) {
+						// If the child refers to its parent, there should be one specific instance to cap into
+						const cappedInstance = capInstances([instance], [parentInstance])[0]
+
+						if (cappedInstance) {
+
+							if (!cappedInstance.caps) cappedInstance.caps = []
+							cappedInstance.caps.push({
+								id: parentInstance.id,
+								start: parentInstance.start,
+								end: parentInstance.end
+							})
+							cappedInstances.push(cappedInstance)
+						}
+					} else {
+						// If the child doesn't refer to its parent, it should be capped within all of its parent instances
+						_.each(parentInstances, parentInstance => {
+
+							const cappedInstance = capInstances([instance], [parentInstance])[0]
+
+							if (cappedInstance) {
+								if (parentInstance) {
+									if (!cappedInstance.caps) cappedInstance.caps = []
+									cappedInstance.caps.push({
+										id: parentInstance.id,
+										start: parentInstance.start,
+										end: parentInstance.end
+									})
+								}
+								cappedInstances.push(cappedInstance)
+							}
+						})
+					}
+				}
+			})
+			instances = cappedInstances
+		}
+		instances = applyRepeatingInstances(
+			instances,
+			lookedupRepeating,
+			resolvedTimeline.options
+		)
 	}
-	instances = applyRepeatingInstances(
-		instances,
-		lookedupRepeating,
-		resolvedTimeline.options
-	)
 
 	// filter out zero-length instances:
 	instances = _.filter(instances, (instance) => {

--- a/src/resolver/validate.ts
+++ b/src/resolver/validate.ts
@@ -1,6 +1,6 @@
 /* tslint:disable:strict-type-predicates */
 import {
-	TimelineObject, TimelineKeyframe
+	TimelineObject, TimelineKeyframe, TimelineEnable
 } from '../api/api'
 import _ = require('underscore')
 
@@ -25,30 +25,29 @@ function validateObject0 (obj: TimelineObject, strict?: boolean, uniqueIds?: Ids
 	if (!obj.content) throw new Error(`Object "${obj.id}": "content" attribute must be set`)
 	if (!obj.enable) throw new Error(`Object "${obj.id}": "enable" attribute must be set`)
 
-	if (obj.enable.start !== undefined) {
-		if (strict && obj.enable.while !== undefined) throw new Error(`Object "${obj.id}": "enable.start" and "enable.while" cannot be combined`)
-		if (strict && obj.enable.instances !== undefined) throw new Error(`Object "${obj.id}": "enable.start" and "enable.instances" cannot be combined`)
+	const enables: TimelineEnable[] = (
+		_.isArray(obj.enable) ?
+		obj.enable :
+		[obj.enable]
+	)
+	_.each(enables, enable => {
 
-		if (
-			strict &&
-			obj.enable.end !== undefined &&
-			obj.enable.duration !== undefined
-		) throw new Error(`Object "${obj.id}": "enable.end" and "enable.duration" cannot be combined`)
+		if (enable.start !== undefined) {
+			if (strict && enable.while !== undefined) throw new Error(`Object "${obj.id}": "enable.start" and "enable.while" cannot be combined`)
 
-	} else if (obj.enable.while !== undefined) {
+			if (
+				strict &&
+				enable.end !== undefined &&
+				enable.duration !== undefined
+			) throw new Error(`Object "${obj.id}": "enable.end" and "enable.duration" cannot be combined`)
 
-		if (strict && obj.enable.end !== undefined) throw new Error(`Object "${obj.id}": "enable.while" and "enable.end" cannot be combined`)
-		if (strict && obj.enable.duration !== undefined) throw new Error(`Object "${obj.id}": "enable.while" and "enable.duration" cannot be combined`)
-		if (strict && obj.enable.instances !== undefined) throw new Error(`Object "${obj.id}": "enable.while" and "enable.instances" cannot be combined`)
+		} else if (enable.while !== undefined) {
 
-	} else if (obj.enable.instances !== undefined) {
+			if (strict && enable.end !== undefined) throw new Error(`Object "${obj.id}": "enable.while" and "enable.end" cannot be combined`)
+			if (strict && enable.duration !== undefined) throw new Error(`Object "${obj.id}": "enable.while" and "enable.duration" cannot be combined`)
 
-		if (strict && obj.enable.end !== undefined) throw new Error(`Object "${obj.id}": "enable.instances" and "enable.end" cannot be combined`)
-		if (strict && obj.enable.duration !== undefined) throw new Error(`Object "${obj.id}": "enable.instances" and "enable.duration" cannot be combined`)
-		if (strict && obj.enable.start !== undefined) throw new Error(`Object "${obj.id}": "enable.instances" and "enable.start" cannot be combined`)
-
-	} else throw new Error(`Object "${obj.id}": "enable.start" or "enable.while" must be set`)
-
+		} else throw new Error(`Object "${obj.id}": "enable.start" or "enable.while" must be set`)
+	})
 	if (obj.keyframes) {
 		_.each(obj.keyframes, (keyframe, i) => {
 			try {
@@ -93,21 +92,29 @@ function validateKeyframe0 (keyframe: TimelineKeyframe, strict?: boolean, unique
 	if (!keyframe.content) throw new Error(`Keyframe "${keyframe.id}": "content" attribute must be set`)
 	if (!keyframe.enable) throw new Error(`Keyframe "${keyframe.id}": "enable" attribute must be set`)
 
-	if (keyframe.enable.start !== undefined) {
-		if (strict && keyframe.enable.while !== undefined) throw new Error(`Keyframe "${keyframe.id}": "enable.start" and "enable.while" cannot be combined`)
+	const enables: TimelineEnable[] = (
+		_.isArray(keyframe.enable) ?
+		keyframe.enable :
+		[keyframe.enable]
+	)
+	_.each(enables, enable => {
 
-		if (
-			strict &&
-			keyframe.enable.end !== undefined &&
-			keyframe.enable.duration !== undefined
-		) throw new Error(`Keyframe "${keyframe.id}": "enable.end" and "enable.duration" cannot be combined`)
+		if (enable.start !== undefined) {
+			if (strict && enable.while !== undefined) throw new Error(`Keyframe "${keyframe.id}": "enable.start" and "enable.while" cannot be combined`)
 
-	} else if (keyframe.enable.while !== undefined) {
+			if (
+				strict &&
+				enable.end !== undefined &&
+				enable.duration !== undefined
+			) throw new Error(`Keyframe "${keyframe.id}": "enable.end" and "enable.duration" cannot be combined`)
 
-		if (strict && keyframe.enable.end !== undefined) throw new Error(`Keyframe "${keyframe.id}": "enable.while" and "enable.end" cannot be combined`)
-		if (strict && keyframe.enable.duration !== undefined) throw new Error(`Keyframe "${keyframe.id}": "enable.while" and "enable.duration" cannot be combined`)
+		} else if (enable.while !== undefined) {
 
-	} else throw new Error(`Keyframe "${keyframe.id}": "enable.start" or "enable.while" must be set`)
+			if (strict && enable.end !== undefined) throw new Error(`Keyframe "${keyframe.id}": "enable.while" and "enable.end" cannot be combined`)
+			if (strict && enable.duration !== undefined) throw new Error(`Keyframe "${keyframe.id}": "enable.while" and "enable.duration" cannot be combined`)
+
+		} else throw new Error(`Keyframe "${keyframe.id}": "enable.start" or "enable.while" must be set`)
+	})
 
 	if (keyframe.classes) {
 		_.each(keyframe.classes, (className, i) => {

--- a/src/resolver/validate.ts
+++ b/src/resolver/validate.ts
@@ -27,6 +27,7 @@ function validateObject0 (obj: TimelineObject, strict?: boolean, uniqueIds?: Ids
 
 	if (obj.enable.start !== undefined) {
 		if (strict && obj.enable.while !== undefined) throw new Error(`Object "${obj.id}": "enable.start" and "enable.while" cannot be combined`)
+		if (strict && obj.enable.instances !== undefined) throw new Error(`Object "${obj.id}": "enable.start" and "enable.instances" cannot be combined`)
 
 		if (
 			strict &&
@@ -38,6 +39,13 @@ function validateObject0 (obj: TimelineObject, strict?: boolean, uniqueIds?: Ids
 
 		if (strict && obj.enable.end !== undefined) throw new Error(`Object "${obj.id}": "enable.while" and "enable.end" cannot be combined`)
 		if (strict && obj.enable.duration !== undefined) throw new Error(`Object "${obj.id}": "enable.while" and "enable.duration" cannot be combined`)
+		if (strict && obj.enable.instances !== undefined) throw new Error(`Object "${obj.id}": "enable.while" and "enable.instances" cannot be combined`)
+
+	} else if (obj.enable.instances !== undefined) {
+
+		if (strict && obj.enable.end !== undefined) throw new Error(`Object "${obj.id}": "enable.instances" and "enable.end" cannot be combined`)
+		if (strict && obj.enable.duration !== undefined) throw new Error(`Object "${obj.id}": "enable.instances" and "enable.duration" cannot be combined`)
+		if (strict && obj.enable.start !== undefined) throw new Error(`Object "${obj.id}": "enable.instances" and "enable.start" cannot be combined`)
 
 	} else throw new Error(`Object "${obj.id}": "enable.start" or "enable.while" must be set`)
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR adds the ability to set instances of a timeline-object.

Like so:
```
const myTimeline = [
    {
        id: 'video0',
        layer: 'L1',
        enable: {
            instances: [
                {start: 0, end: 10},
                {start: 25, end: 30},
                {start: 97, end: 101},
           ]
        },
        content: {}
    },
]
```
The intention is that this could be used by a pre-processor of the timeline, which inserts certain elements, that are then used by the timeline resolver.
