### PR TITLE
chore: unit test for child object end time not being made absolute

### DIFF
--- a/src/resolver/__tests__/resolver/groups.spec.ts
+++ b/src/resolver/__tests__/resolver/groups.spec.ts
@@ -683,4 +683,120 @@ describe('Resolver, groups', () => {
 			end: 160
 		})
 	})
+	test('Child object with end time - numeric start', () => {
+		const baseTime = 1599753027264.5 // Some real point in time
+		const timeline: TimelineObject[] = [
+			{
+				id: 'grp0',
+				enable: {
+					start: baseTime
+				},
+				layer: 'parent',
+				content: {},
+				isGroup: true,
+				children: [
+					{
+						id: 'obj0',
+						content: {},
+						enable: {
+							start: 0,
+							duration: 480
+						},
+						layer: 'layer0'
+					},
+					{
+						id: 'obj1',
+						content: {},
+						enable: {
+							start: 0,
+							end: 86400000
+						},
+						layer: 'layer1'
+					}
+				]
+			}
+		]
+
+		const resolved = Resolver.resolveAllStates(Resolver.resolveTimeline(timeline, { time: baseTime + 1000, limitCount: 10, limitTime: 999 }))
+		expect(resolved.statistics.resolvedObjectCount).toEqual(3)
+
+		// // All 3 videos should start at the same time:
+		expect(resolved.objects['grp0']).toBeTruthy()
+		expect(resolved.objects['obj0']).toBeTruthy()
+		expect(resolved.objects['obj1']).toBeTruthy()
+		expect(resolved.objects['grp0'].resolved.instances).toHaveLength(1)
+		expect(resolved.objects['obj0'].resolved.instances).toHaveLength(1)
+		expect(resolved.objects['obj1'].resolved.instances).toHaveLength(1)
+
+		expect(resolved.objects['grp0'].resolved.instances[0]).toMatchObject({
+			start: baseTime,
+			end: null
+		})
+		expect(resolved.objects['obj0'].resolved.instances[0]).toMatchObject({
+			start: baseTime,
+			end: baseTime + 480
+		})
+		expect(resolved.objects['obj1'].resolved.instances[0]).toMatchObject({
+			start: baseTime,
+			end: baseTime + 86400000
+		})
+	})
+	test('Child object with end time - reference start', () => {
+		const baseTime = 1599753027264.5 // Some real point in time
+		const timeline: TimelineObject[] = [
+			{
+				id: 'grp0',
+				enable: {
+					start: baseTime
+				},
+				layer: 'parent',
+				content: {},
+				isGroup: true,
+				children: [
+					{
+						id: 'obj0',
+						content: {},
+						enable: {
+							start: 0,
+							duration: 480
+						},
+						layer: 'layer0'
+					},
+					{
+						id: 'obj1',
+						content: {},
+						enable: {
+							start: '#obj0.start + 0',
+							end: 86400000
+						},
+						layer: 'layer1'
+					}
+				]
+			}
+		]
+
+		const resolved = Resolver.resolveAllStates(Resolver.resolveTimeline(timeline, { time: baseTime + 1000, limitCount: 10, limitTime: 999 }))
+		expect(resolved.statistics.resolvedObjectCount).toEqual(3)
+
+		// // All 3 videos should start at the same time:
+		expect(resolved.objects['grp0']).toBeTruthy()
+		expect(resolved.objects['obj0']).toBeTruthy()
+		expect(resolved.objects['obj1']).toBeTruthy()
+		expect(resolved.objects['grp0'].resolved.instances).toHaveLength(1)
+		expect(resolved.objects['obj0'].resolved.instances).toHaveLength(1)
+		expect(resolved.objects['obj1'].resolved.instances).toHaveLength(1)
+
+		expect(resolved.objects['grp0'].resolved.instances[0]).toMatchObject({
+			start: baseTime,
+			end: null
+		})
+		expect(resolved.objects['obj0'].resolved.instances[0]).toMatchObject({
+			start: baseTime,
+			end: baseTime + 480
+		})
+		expect(resolved.objects['obj1'].resolved.instances[0]).toMatchObject({
+			start: baseTime,
+			end: baseTime + 86400000
+		})
+	})
 })

--- a/src/resolver/resolver.ts
+++ b/src/resolver/resolver.ts
@@ -353,7 +353,7 @@ export function resolveTimelineObj (resolvedTimeline: ResolvedTimeline, obj: Res
 
 		let parentInstances: TimelineObjectInstance[] | null = null
 		let hasParent: boolean = false
-		let referToParent: boolean = false
+		let startRefersToParent: boolean = false
 		if (obj.resolved.parentId) {
 			hasParent = true
 
@@ -368,14 +368,14 @@ export function resolveTimelineObj (resolvedTimeline: ResolvedTimeline, obj: Res
 
 			if (isConstant(startExpr)) {
 				// Only use parent if the expression resolves to a number (ie doesn't contain any references)
-				referToParent = true
+				startRefersToParent = true
 			}
 		}
 		const lookupStart = lookupExpression(resolvedTimeline, obj, startExpr, 'start')
 		let lookedupStarts = lookupStart.instances
 		directReferences = directReferences.concat(lookupStart.allReferences)
 
-		if (referToParent) {
+		if (startRefersToParent) {
 			lookedupStarts = applyParentInstances(parentInstances, lookedupStarts)
 		}
 
@@ -413,13 +413,20 @@ export function resolveTimelineObj (resolvedTimeline: ResolvedTimeline, obj: Res
 			}
 
 			if (enable.end !== undefined) {
-
 				const endExpr: Expression = interpretExpression(enable.end)
+				let endRefersToParent: boolean = false
+				if (obj.resolved.parentId) {
+					if (isConstant(endExpr)) {
+						// Only use parent if the expression resolves to a number (ie doesn't contain any references)
+						endRefersToParent = true
+					}
+				}
+
 				// lookedupEnds will contain an inverted list of instances. Therefore .start means an end
 				const lookupEnd = endExpr ? lookupExpression(resolvedTimeline, obj, endExpr, 'end') : null
 				let lookedupEnds = lookupEnd ? lookupEnd.instances : null
 				if (lookupEnd) directReferences = directReferences.concat(lookupEnd.allReferences)
-				if (referToParent && isConstant(endExpr)) {
+				if (endRefersToParent) {
 					lookedupEnds = applyParentInstances(parentInstances, lookedupEnds)
 				}
 				if (_.isArray(lookedupEnds)) {


### PR DESCRIPTION
This adds a pair of unit tests, the only difference is that the start of obj1 changes from `0` to `#obj0.start + 0` (which will resolve to 0).

This causes the resolver to produce an incorrect result, with the instance changing from
```
{
    "id": "obj1",
    "start": 1599753027264.5,
    "end": 1599839427264.5,,
    "references": []
}
```
to 
```
{
    "id": "obj1",
    "start": 1599753027264.5,
    "end": 86400000,
    "references": []
}
```