### PR TITLE
bug: non alphabetical groups producing zero length instance

### DIFF
--- a/src/resolver/__tests__/resolver/groups.spec.ts
+++ b/src/resolver/__tests__/resolver/groups.spec.ts
@@ -366,7 +366,7 @@ describe('Resolver, groups', () => {
 
 		expect(resolved.objects['group1'].resolved).toMatchObject({
 			resolved: true,
-			instances: [{ start: 10, end: 50 }], // because group 1 started
+			instances: [{ start: 10, end: 50 }], // because group 0 started
 		})
 		expect(resolved.objects['child0'].resolved).toMatchObject({
 			resolved: true,
@@ -397,6 +397,7 @@ describe('Resolver, groups', () => {
 				{ objId: 'child0', time: 100, type: EventType.END },
 				{ objId: 'child1', time: 100, type: EventType.END },
 				{ objId: 'group0', time: 100, type: EventType.END },
+				// { objId: 'group0', time: 100, type: EventType.START },
 			],
 		})
 		expect(Resolver.getState(resolved, 56)).toMatchObject({
@@ -412,6 +413,7 @@ describe('Resolver, groups', () => {
 				{ objId: 'child0', time: 100, type: EventType.END },
 				{ objId: 'child1', time: 100, type: EventType.END },
 				{ objId: 'group0', time: 100, type: EventType.END },
+				// { objId: 'group0', time: 100, type: EventType.START }
 			],
 		})
 		const state1 = Resolver.getState(resolved, 120)

--- a/src/resolver/state.ts
+++ b/src/resolver/state.ts
@@ -265,14 +265,31 @@ export function resolveStates(resolved: ResolvedTimeline, onlyForTime?: Time, ca
 							// Update activeObjIds:
 							delete activeObjIds[prevObj.id]
 
-							// Add to nextEvents:
-							if (!onlyForTime || time > onlyForTime) {
-								resolvedStates.nextEvents.push({
-									type: EventType.END,
-									time: time,
-									objId: prevObj.id,
-								})
-								eventObjectTimes[instance.end + ''] = EventType.END
+							if (prevObj.instance.start === prevObj.instance.end) {
+								// Strip out this zero-length instance
+
+								const index = prevObj.resolved.instances.findIndex((i) => i.id === prevObj.instance.id)
+								if (index !== -1) {
+									prevObj.resolved.instances.splice(index, 1)
+								}
+
+								const index2 = resolvedStates.nextEvents.findIndex(
+									(e) => e.objId === prevObj.id && e.type === EventType.START && e.time === time
+								)
+								if (index2 !== -1) {
+									resolvedStates.nextEvents.splice(index2, 1)
+								}
+								console.log('ind', index2, index, prevObj.id)
+							} else {
+								// Add to nextEvents:
+								if (!onlyForTime || time > onlyForTime) {
+									resolvedStates.nextEvents.push({
+										type: EventType.END,
+										time: time,
+										objId: prevObj.id,
+									})
+									eventObjectTimes[instance.end + ''] = EventType.END
+								}
 							}
 						}
 					}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug fix

* **What is the current behavior?** (You can also link to an open issue here)

sometimes instances can be created in the state with the start and end times being the same. their existence depends on the ids of the objects, and so which one gets stopped first

see unit test

* **Other information**:
