### PR TITLE
Add test for how to deal with repeating object that are interrupted by another object

### DIFF
--- a/src/resolver/__tests__/resolver/basic.spec.ts
+++ b/src/resolver/__tests__/resolver/basic.spec.ts
@@ -496,7 +496,7 @@ describe('Resolver, basic', () => {
 		expect(resolved.objects['obj1'].resolved.instances).toMatchObject([
 			{ start: 22, end: 30 },
 			{ start: 35, end: 40 },
-			{ start: 45, end: null },
+			{ start: 45, end: null }, // because the repeating obj0 is limited by limitCount: 5
 		])
 		expect(resolved.objects['obj0'].resolved.instances).toMatchObject([
 			{ start: 0, end: 5 },


### PR DESCRIPTION
This PR adds a unit test, because there exists no test to explicitly define the wanted behavior.

Merging is pending of a discussion if this is the wanted behavior.
