### PR TITLE
bug: when groups overlap, child objects can outlive the parent

### DIFF
--- a/src/resolver/__tests__/resolver/groups.spec.ts
+++ b/src/resolver/__tests__/resolver/groups.spec.ts
@@ -912,6 +912,14 @@ describeVariants(
 					end: null,
 				},
 			])
+
+			expect(Resolver.getState(resolved, baseTime + 110).layers['layer1']).toMatchObject({ id: 'grp0' })
+			expect(Resolver.getState(resolved, baseTime + 110).layers['layer1_0']).toMatchObject({ id: 'grp0_obj0' })
+
+			expect(Resolver.getState(resolved, baseTime + 130).layers['layer1']).toMatchObject({ id: 'grp1' })
+
+			// Should be empty, since it is capped by its parent (also evidenced by the instances before)
+			expect(Resolver.getState(resolved, baseTime + 130).layers['layer1_0']).toBeFalsy()
 		})
 		test('groups replacing each other, capping children in lower levels', () => {
 			// ensure that capping of children works multiple levels down, and with repeating parents

--- a/src/resolver/__tests__/resolver/groups.spec.ts
+++ b/src/resolver/__tests__/resolver/groups.spec.ts
@@ -891,11 +891,27 @@ describeVariants(
 			expect(resolved.objects['grp1'].resolved.instances).toHaveLength(1)
 
 			// expect grp0 to be ended by grp1 replacing it on the layer
-			expect(resolved.objects['grp0'].resolved.instances[0].end).toBe(baseTime + 120)
+			expect(resolved.objects['grp0'].resolved.instances).toMatchObject([
+				{
+					start: baseTime + 100,
+					end: baseTime + 120,
+				},
+			])
 			// expect grp0_obj0 to be ended by grp0 ending, ended by grp1 replacing it
-			expect(resolved.objects['grp0_obj0'].resolved.instances[0].end).toBe(baseTime + 120)
+			expect(resolved.objects['grp0_obj0'].resolved.instances).toMatchObject([
+				{
+					start: baseTime + 100,
+					end: baseTime + 120,
+				},
+			])
 			// expect grp1 to be infinite
 			expect(resolved.objects['grp1'].resolved.instances[0].end).toBe(null)
+			expect(resolved.objects['grp1'].resolved.instances).toMatchObject([
+				{
+					start: baseTime + 120,
+					end: null,
+				},
+			])
 		})
 		test('groups replacing each other, capping children in lower levels', () => {
 			// ensure that capping of children works multiple levels down, and with repeating parents


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

unit test

* **What is the current behavior?** (You can also link to an open issue here)

As shown, there are two groups on the same layer. They are on a named layer, so only one can be active at a time.
The all-states object correctly tracks the times of everything.

But getting a state during the point where the groups 'overlap', can return objects from both groups.

As shown in this test block
```
{
	// before 'end' of grp0
	const state = Resolver.getState(resolved, 5200)
	expect(state.layers['layer1']).toBeTruthy()
	expect(state.layers['layer1']).toMatchObject({
		id: 'grp1',
	})

	expect(state.layers['layer0']).toBeFalsy()
}
```
`state.layers['layer0']` ends up with object `grp0_0`, which is incorrect

* **What is the new behavior (if this is a feature change)?**



* **Other information**:

In sofie we are relying on this behaviour, so we need to stop having groups overlap there before we can pull in a fix for this