### PR TITLE
Validate strings

### DIFF
--- a/src/__tests__/timelineGenerator.ts
+++ b/src/__tests__/timelineGenerator.ts
@@ -11,7 +11,7 @@ export function generateTimeline(seed: number, maxCount: number, maxGroupDepth: 
 	const layers: string[] = []
 	const layerCount = Math.ceil(random.get() * maxCount * 0.3)
 	for (let i = 0; i < layerCount; i++) {
-		layers.push('layer' + random.get())
+		layers.push('layer' + random.getInt(10000))
 	}
 	const objectIds: string[] = []
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export * from './api/enums'
 export * from './api/api'
 export { Resolver } from './resolver/resolver'
-export { validateTimeline, validateObject, validateKeyframe } from './resolver/validate'
+export { validateTimeline, validateObject, validateKeyframe, validateIdString } from './resolver/validate'

--- a/src/resolver/__tests__/validate.spec.ts
+++ b/src/resolver/__tests__/validate.spec.ts
@@ -81,6 +81,12 @@ describe('validate', () => {
 
 		expect(() => {
 			const o = _.clone(obj)
+			o.enable = [o.enable as TimelineEnable]
+			validateObject(o, true)
+		}).not.toThrowError()
+
+		expect(() => {
+			const o = _.clone(obj)
 			o.enable = {
 				start: 10,
 				end: 32,
@@ -212,6 +218,18 @@ describe('validate', () => {
 
 		expect(() => {
 			const o = _.clone(keyframe)
+			o.enable = [
+				{
+					start: 10,
+					end: 32,
+					duration: 22,
+				},
+			]
+			validateKeyframe(o, true)
+		}).toThrowError()
+
+		expect(() => {
+			const o = _.clone(keyframe)
 			o.enable = {
 				while: 1,
 				end: 32,
@@ -270,6 +288,13 @@ describe('validate', () => {
 			o.keyframes[0].id = obj.id
 			validateObject(o, true)
 		}).toThrowError()
+
+		expect(() => {
+			const o = _.clone(obj)
+			// @ts-ignore
+			o.classes = [123]
+			validateObject(o, true)
+		}).toThrowError()
 	})
 	test('validateTimeline', () => {
 		expect(() => {
@@ -316,21 +341,24 @@ describe('validate', () => {
 	test('invalid id-strings', () => {
 		expect(() => {
 			const tl = _.clone(timeline)
+			tl[0] = _.clone(tl[0])
 			tl[0].id = 'obj-1'
 			validateTimeline(tl, false)
-		}).toThrowError()
+		}).toThrowError(/id/)
 
 		expect(() => {
 			const tl = _.clone(timeline)
+			tl[0] = _.clone(tl[0])
 
 			tl[0].classes = ['class-1']
 			validateTimeline(tl, false)
-		}).toThrowError()
+		}).toThrowError(/class/)
 		expect(() => {
 			const tl = _.clone(timeline)
+			tl[0] = _.clone(tl[0])
 
 			tl[0].layer = 'layer-1'
 			validateTimeline(tl, false)
-		}).toThrowError()
+		}).toThrowError(/layer/)
 	})
 })

--- a/src/resolver/__tests__/validate.spec.ts
+++ b/src/resolver/__tests__/validate.spec.ts
@@ -1,4 +1,4 @@
-import { validateObject, validateKeyframe, validateTimeline } from '../validate'
+import { validateObject, validateKeyframe, validateTimeline, validateIdString } from '../validate'
 import { TimelineObject, TimelineKeyframe, TimelineEnable } from '../../api/api'
 import _ = require('underscore')
 
@@ -280,6 +280,56 @@ describe('validate', () => {
 		expect(() => {
 			const tl = _.clone(timeline)
 			tl[1].id = tl[0].id
+			validateTimeline(tl, false)
+		}).toThrowError()
+	})
+	test('validateIdString', () => {
+		expect(() => validateIdString('')).not.toThrowError()
+		expect(() => validateIdString('test')).not.toThrowError()
+		expect(() => validateIdString('abcABC123_')).not.toThrowError()
+		expect(() => validateIdString('_¤"\'£€\\,;:¨~')).not.toThrowError()
+
+		expect(() => validateIdString('test-1')).toThrowError()
+		expect(() => validateIdString('test+1')).toThrowError()
+		expect(() => validateIdString('test/1')).toThrowError()
+		expect(() => validateIdString('test*1')).toThrowError()
+		expect(() => validateIdString('test%1')).toThrowError()
+		expect(() => validateIdString('test&1')).toThrowError()
+		expect(() => validateIdString('test|1')).toThrowError()
+		expect(() => validateIdString('test!')).toThrowError()
+		expect(() => validateIdString('test(')).toThrowError()
+		expect(() => validateIdString('test)')).toThrowError()
+		expect(() => validateIdString('#test')).toThrowError() // a reference to an object id
+		expect(() => validateIdString('.test')).toThrowError() // a reference to an object class
+		expect(() => validateIdString('$test')).toThrowError() // a reference to an object layer
+
+		// These aren't currently in use anywhere, but might be so in the future:
+		expect(() => validateIdString('test§', true)).toThrowError()
+		expect(() => validateIdString('test^', true)).toThrowError()
+		expect(() => validateIdString('test?', true)).toThrowError()
+		expect(() => validateIdString('test=', true)).toThrowError()
+		expect(() => validateIdString('test{', true)).toThrowError()
+		expect(() => validateIdString('test}', true)).toThrowError()
+		expect(() => validateIdString('test[', true)).toThrowError()
+		expect(() => validateIdString('test]', true)).toThrowError()
+	})
+	test('invalid id-strings', () => {
+		expect(() => {
+			const tl = _.clone(timeline)
+			tl[0].id = 'obj-1'
+			validateTimeline(tl, false)
+		}).toThrowError()
+
+		expect(() => {
+			const tl = _.clone(timeline)
+
+			tl[0].classes = ['class-1']
+			validateTimeline(tl, false)
+		}).toThrowError()
+		expect(() => {
+			const tl = _.clone(timeline)
+
+			tl[0].layer = 'layer-1'
 			validateTimeline(tl, false)
 		}).toThrowError()
 	})

--- a/src/resolver/expression.ts
+++ b/src/resolver/expression.ts
@@ -4,7 +4,7 @@ import { isNumeric, isConstant, cacheResult } from '../lib'
 
 export const OPERATORS = ['&', '|', '+', '-', '*', '/', '%', '!']
 
-const REGEXP_OPERATORS = _.map(OPERATORS, (o) => '\\' + o).join('')
+export const REGEXP_OPERATORS = new RegExp('([' + _.map(OPERATORS, (o) => '\\' + o).join('') + '\\(\\)])', 'g')
 
 export function interpretExpression(expression: null): null
 export function interpretExpression(expression: number): number
@@ -18,7 +18,7 @@ export function interpretExpression(expression: Expression): Expression {
 		return cacheResult(
 			expressionString,
 			() => {
-				const expr = expressionString.replace(new RegExp('([' + REGEXP_OPERATORS + '\\(\\)])', 'g'), ' $1 ') // Make sure there's a space between every operator & operand
+				const expr = expressionString.replace(REGEXP_OPERATORS, ' $1 ') // Make sure there's a space between every operator & operand
 
 				const words: Array<string> = _.compact(expr.split(' '))
 

--- a/src/resolver/validate.ts
+++ b/src/resolver/validate.ts
@@ -32,16 +32,6 @@ function validateObject0(obj: TimelineObject, strict?: boolean, uniqueIds?: Ids)
 		throw new Error(`Object "${obj.id}": "layer" attribute: ${err}`)
 	}
 
-	if (obj.classes) {
-		for (const className of obj.classes) {
-			try {
-				validateIdString(className, strict)
-			} catch (err) {
-				throw new Error(`Object "${obj.id}": "classes" attribute: ${err}`)
-			}
-		}
-	}
-
 	if (!obj.content) throw new Error(`Object "${obj.id}": "content" attribute must be set`)
 	if (!obj.enable) throw new Error(`Object "${obj.id}": "enable" attribute must be set`)
 
@@ -77,6 +67,12 @@ function validateObject0(obj: TimelineObject, strict?: boolean, uniqueIds?: Ids)
 			const className = obj.classes[i]
 			if (className && typeof className !== 'string')
 				throw new Error(`Object "${obj.id}": "classes[${i}]" is not a string`)
+
+			try {
+				validateIdString(className, strict)
+			} catch (err) {
+				throw new Error(`Object "${obj.id}": "classes[${i}]": ${err}`)
+			}
 		}
 	}
 

--- a/src/resolver/validate.ts
+++ b/src/resolver/validate.ts
@@ -1,6 +1,7 @@
 /* tslint:disable:strict-type-predicates */
 import { TimelineObject, TimelineKeyframe, TimelineEnable } from '../api/api'
 import _ = require('underscore')
+import { REGEXP_OPERATORS } from './expression'
 
 interface Ids {
 	[id: string]: true
@@ -142,4 +143,46 @@ export function validateObject(obj: TimelineObject, strict?: boolean): void {
  */
 export function validateKeyframe(keyframe: TimelineKeyframe, strict?: boolean): void {
 	validateKeyframe0(keyframe, strict)
+}
+
+/** These characters are reserved and cannot be used in ids, etc */
+const RESERVED_CHARACTERS = /[#.$]/
+
+/** These characters are reserved for possible future use and cannot be used in ids, etc */
+const FUTURE_RESERVED_CHARACTERS = /[=?@{}[\]^§]/
+
+/**
+ * Validates a string that is used in Timeline as a reference (an id, a class or layer)
+ * @param str The string to validate
+ * @param strict Set to true to enable some strict rules (rules that can possibly be ignored)
+ */
+export function validateIdString(str: string, strict?: boolean): void {
+	if (!str) return
+	{
+		const m = str.match(REGEXP_OPERATORS)
+		if (m) {
+			throw new Error(
+				`The string "${str}" contains a character ("${m[1]}") which isn't allowed in Timeline (is an operator)`
+			)
+		}
+	}
+	{
+		const m = str.match(RESERVED_CHARACTERS)
+		if (m) {
+			throw new Error(
+				`The string "${str}" contains a character ("${m[1]}") which isn't allowed in Timeline (is a reserved character)`
+			)
+		}
+	}
+	if (strict) {
+		// Also check a few characters that are technically allowed today, but *might* become used in future versions of Timeline:
+		{
+			const m = str.match(FUTURE_RESERVED_CHARACTERS)
+			if (m) {
+				throw new Error(
+					`The string "${str}" contains a character ("${m[0]}") which isn't allowed in Timeline (is an reserved character and might be used in the future)`
+				)
+			}
+		}
+	}
 }

--- a/src/resolver/validate.ts
+++ b/src/resolver/validate.ts
@@ -15,10 +15,32 @@ function validateObject0(obj: TimelineObject, strict?: boolean, uniqueIds?: Ids)
 	if (!obj.id) throw new Error(`Object missing "id" attribute`)
 	if (typeof obj.id !== 'string') throw new Error(`Object "id" attribute is not a string: "${obj.id}"`)
 
+	try {
+		validateIdString(obj.id, strict)
+	} catch (err) {
+		throw new Error(`Object "id" attribute: ${err}`)
+	}
+
 	if (uniqueIds[obj.id]) throw new Error(`Object id "${obj.id}" is not unique`)
 	uniqueIds[obj.id] = true
 
 	if (obj.layer === undefined) throw new Error(`Object "${obj.id}": "layer" attribute is undefined`)
+
+	try {
+		validateIdString(obj.layer + '', strict)
+	} catch (err) {
+		throw new Error(`Object "${obj.id}": "layer" attribute: ${err}`)
+	}
+
+	if (obj.classes) {
+		for (const className of obj.classes) {
+			try {
+				validateIdString(className, strict)
+			} catch (err) {
+				throw new Error(`Object "${obj.id}": "classes" attribute: ${err}`)
+			}
+		}
+	}
 
 	if (!obj.content) throw new Error(`Object "${obj.id}": "content" attribute must be set`)
 	if (!obj.enable) throw new Error(`Object "${obj.id}": "enable" attribute must be set`)


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix


* **What is the current behavior?** (You can also link to an open issue here)
It is possible to send in strings in id, classes or layers that crashes the Timeline when resolving it.
For example `id: "test--1"`


* **What is the new behavior (if this is a feature change)?**
ids, classes and layers are now validated before resolving.

Also exports a new function, `validateIdString()` that can be used to validate strings to find issues early


* **Other information**:
