### PR TITLE
fix: instances capped to zero duration get stuck in state

### DIFF
--- a/src/resolver/__tests__/resolver/groups.spec.ts
+++ b/src/resolver/__tests__/resolver/groups.spec.ts
@@ -1414,7 +1414,7 @@ describeVariants(
 				{ objId: 'tema_capped', time: 2480, type: 0 },
 			])
 
-			const state1 = Resolver.getState(resolved, Date.now())
+			const state1 = Resolver.getState(resolved, 5000)
 			expect(state1.layers['l1']).toBeTruthy()
 			expect(state1.layers['l1'].id).toBe('tema_baseline') // baseline
 			expect(state1.layers['l1'].instance.start).toBe(2480)
@@ -1493,7 +1493,7 @@ describeVariants(
 			)
 			// expect(resolved.statistics.resolvedObjectCount).toEqual(6)
 
-			const state1 = Resolver.getState(resolved, Date.now())
+			const state1 = Resolver.getState(resolved, 5000)
 			expect(state1.layers['l1']).toBeFalsy()
 		})
 	},

--- a/src/resolver/__tests__/resolver/groups.spec.ts
+++ b/src/resolver/__tests__/resolver/groups.spec.ts
@@ -1318,6 +1318,95 @@ describeVariants(
 				expect(state.layers['layer0']).toBeFalsy()
 			}
 		})
+
+		test('Child object partially blocked by other object', () => {
+			const baseTime = 3000 // Some real point in time
+			const timeline = fixTimeline([
+				{
+					id: 'tema_baseline',
+					enable: {
+						while: 1,
+					},
+					priority: 0,
+					layer: 'l1',
+					content: {},
+				},
+
+				{
+					id: 'group0',
+					enable: {
+						start: 1000,
+						end: '#group1.start + 480',
+					},
+					priority: -1,
+					layer: '',
+					content: {},
+					children: [
+						{
+							id: 'group2',
+							content: {},
+							children: [
+								// Note: moving this out a level gives different results
+								{
+									id: 'tema_capped',
+									enable: {
+										start: 0,
+									},
+									priority: 1,
+									layer: 'l1',
+									content: {},
+								},
+							],
+							isGroup: true,
+							enable: {
+								start: 700,
+							},
+							layer: '',
+						},
+					],
+					isGroup: true,
+				},
+
+				{
+					id: 'group1',
+					enable: {
+						start: 2000,
+					},
+					priority: 5,
+					layer: '',
+					content: {},
+					children: [
+						{
+							id: 'tema_blocker',
+							enable: {
+								start: 0,
+								duration: 480,
+							},
+							priority: 10,
+							layer: 'l1',
+							content: {},
+						},
+					],
+					isGroup: true,
+				},
+			])
+
+			const resolved = Resolver.resolveAllStates(
+				Resolver.resolveTimeline(timeline, {
+					cache: getCache(),
+					time: baseTime + 1000,
+					limitCount: 10,
+					limitTime: 999,
+				})
+			)
+			expect(resolved.statistics.resolvedObjectCount).toEqual(6)
+
+			const state1 = Resolver.getState(resolved, Date.now())
+			expect(state1.layers['l1']).toBeTruthy()
+			expect(state1.layers['l1'].id).toBe('tema_baseline') // baseline
+			expect(state1.layers['l1'].instance.start).toBe(2480)
+			expect(state1.layers['l1'].instance.end).toBe(null)
+		})
 	},
 	{
 		normal: true,

--- a/src/resolver/state.ts
+++ b/src/resolver/state.ts
@@ -337,7 +337,7 @@ export function resolveStates(resolved: ResolvedTimeline, cache?: ResolverCache)
 						resolvedStates.nextEvents.push({
 							type: EventType.START,
 							time: newInstance.start,
-							objId: obj.id,
+							objId: newObj.id,
 						})
 						eventObjectTimes[newInstance.start + ''] = EventType.START
 
@@ -496,6 +496,8 @@ export function resolveStates(resolved: ResolvedTimeline, cache?: ResolverCache)
 
 			if (!obj.resolved.isKeyframe) {
 				for (const instance of obj.resolved.instances) {
+					if (instance.start === instance.end) continue
+
 					const startTime = instance.start + ''
 					if (!stateLayer[startTime]) {
 						stateLayer[startTime] = {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

bug

* **What is the current behavior?** (You can also link to an open issue here)

Sometimes objects can be given a start and end time of the same point in time, and appear in the state as a start with no end

* **Other information**:

related to https://github.com/SuperFlyTV/supertimeline/pull/79 ?