### PR TITLE
Add tracing of resolve, for troubleshooting

### DIFF
--- a/src/__tests__/basic.spec.ts
+++ b/src/__tests__/basic.spec.ts
@@ -1,6 +1,7 @@
 /* eslint-disable jest/no-standalone-expect */
 
 import { EventType, ResolvedTimelineObject, TimelineObjectInstance, getResolvedState, resolveTimeline } from '..'
+
 import { baseInstances } from '../resolver/lib/instance'
 import { describeVariants } from './testlib'
 
@@ -1695,6 +1696,7 @@ describeVariants(
 				resolvedKeyframeCount: 0,
 				resolvingObjectCount: 0,
 				resolvingCount: 0,
+				resolveTrace: [],
 			})
 		})
 		test('Class state overrides', () => {

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -7,8 +7,8 @@ import {
 	resolveTimeline,
 	getResolvedState,
 	applyKeyframeContent,
+	ResolveError,
 } from '../index'
-import { ResolveError } from '../resolver/lib/Error'
 import { baseInstances } from '../resolver/lib/instance'
 import { clone } from '../resolver/lib/lib'
 

--- a/src/__tests__/index.spec.ts
+++ b/src/__tests__/index.spec.ts
@@ -8,6 +8,7 @@ import {
 	getResolvedState,
 	applyKeyframeContent,
 } from '../index'
+import { ResolveError } from '../resolver/lib/Error'
 import { baseInstances } from '../resolver/lib/instance'
 import { clone } from '../resolver/lib/lib'
 
@@ -878,5 +879,69 @@ describe('index', () => {
 		])
 
 		expect(state1.layers['layerA']).toEqual(state1NoCache.layers['layerA'])
+	})
+	test('traceResolving', () => {
+		const timeline: TimelineObject<any>[] = [
+			{
+				id: 'A',
+				layer: 'L',
+				enable: { start: 100, duration: 1 },
+				content: {},
+				priority: 0,
+			},
+		]
+
+		const resolved = resolveTimeline(timeline, {
+			cache: {},
+			time: 0,
+			traceResolving: true,
+		})
+
+		// Note: The exact content of the trace isn't that important, since it's for troubleshooting purposes
+		expect(resolved.statistics.resolveTrace).toMatchObject([
+			'init',
+			'resolveTimeline start',
+			'timeline object count 1',
+			'objects: 1',
+			'using cache',
+			'cache: init',
+			'cache: canUseIncomingCache: false',
+			'cache: cached objects: []',
+			'cache: object "A" is new',
+			'Resolver: Step 1a',
+			'Resolver: Resolve object "A"',
+			'Resolver: object "A" resolved.instances: [{"id":"@A_0","start":100,"end":101,"references":[]}]',
+			'Resolver: object "A" directReferences: []',
+			'Resolver: Step 1b',
+			'Resolver: Resolve conflicts for layers: ["L"]',
+			'LayerState: Resolve conflicts for layer "L", objects: A',
+			'Resolver: Step 2',
+			'resolveTimeline done!',
+		])
+	})
+	test('thrown errors should be ResolveError', () => {
+		const timeline: TimelineObject<any>[] = [
+			{
+				id: 'A',
+				layer: 'L',
+				enable: { start: 'badexpression((' },
+				content: {},
+				priority: 0,
+			},
+		]
+
+		{
+			let error: any = null
+			try {
+				resolveTimeline(timeline, {
+					time: 0,
+					traceResolving: true,
+				})
+			} catch (e) {
+				error = e
+			}
+			expect(error).toBeInstanceOf(ResolveError)
+			expect(error.resolvedTimeline).toBeTruthy()
+		}
 	})
 })

--- a/src/api/resolvedTimeline.ts
+++ b/src/api/resolvedTimeline.ts
@@ -48,6 +48,9 @@ export interface ResolvedTimeline<TContent extends Content = Content> {
 		 * (is affected when using cache)
 		 */
 		resolvingCount: number
+
+		/** If traceResolving option is enabled, will contain a trace of the steps the resolver did while resolving */
+		resolveTrace: string[]
 	}
 	/** Is set if there was an error during Resolving and options.dontThrowOnError is set. */
 	error?: Error

--- a/src/api/resolver.ts
+++ b/src/api/resolver.ts
@@ -38,6 +38,12 @@ export interface ResolveOptions {
 	debug?: boolean
 
 	/**
+	 * If true, will store traces of the resolving into resolvedTimeline.statistics.resolveTrace.
+	 * This decreases performance slightly.
+	 */
+	traceResolving?: boolean
+
+	/**
 	 * Skip timeline validation.
 	 * This improves performance slightly, but will not catch errors in the input timeline so use with caution.
 	 */
@@ -46,7 +52,7 @@ export interface ResolveOptions {
 	/** Skip generating statistics, this improves performance slightly. */
 	skipStatistics?: boolean
 
-	/** Don't throw when an error (such as circular dependency) occurs. The Error will instead be written to resolvedTimeline.error */
+	/** Don't throw when a timeline-error (such as circular dependency) occurs. The Error will instead be written to resolvedTimeline.error */
 	dontThrowOnError?: boolean
 }
 export interface ResolverCache<TContent extends Content = Content> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
 	TimelineObject,
 } from './api'
 export * from './api'
+export { ResolveError } from './resolver/lib/Error'
 
 import { StateHandler } from './resolver/StateHandler'
 import { ExpressionHandler } from './resolver/ExpressionHandler'

--- a/src/resolver/CacheHandler.ts
+++ b/src/resolver/CacheHandler.ts
@@ -17,8 +17,7 @@ export class CacheHandler {
 
 		if (!cache.canBeUsed) {
 			// Reset the cache:
-			cache.objHashes = {}
-			cache.objects = {}
+			CacheHandler.resetCache(cache)
 
 			this.canUseIncomingCache = false
 		} else {
@@ -207,6 +206,12 @@ export class CacheHandler {
 		}
 
 		toc()
+	}
+	/** Resets / Clears the cache */
+	static resetCache(cache: Partial<ResolverCache>): void {
+		delete cache.canBeUsed
+		cache.objHashes = {}
+		cache.objects = {}
 	}
 }
 /** Return a "hash-string" which changes whenever anything that affects timing of a timeline-object has changed. */

--- a/src/resolver/CacheHandler.ts
+++ b/src/resolver/CacheHandler.ts
@@ -25,13 +25,18 @@ export class CacheHandler {
 			this.canUseIncomingCache = true
 		}
 
+		if (this.resolvedTimeline.traceResolving) {
+			this.resolvedTimeline.addResolveTrace(`cache: init`)
+			this.resolvedTimeline.addResolveTrace(`cache: canUseIncomingCache: ${this.canUseIncomingCache}`)
+			this.resolvedTimeline.addResolveTrace(
+				`cache: cached objects: ${JSON.stringify(Object.keys(cache.objects))}`
+			)
+		}
+
 		// cache.canBeUsed will be set in this.persistData()
 		cache.canBeUsed = false
 
 		this.cache = cache as ResolverCache
-	}
-	private debug(...args: any[]) {
-		if (this.resolvedTimeline.options.debug) console.log(...args)
 	}
 	public determineChangedObjects(): void {
 		const toc = tic('  cache.determineChangedObjects')
@@ -45,8 +50,15 @@ export class CacheHandler {
 			const newHash = hashTimelineObject(obj)
 			allNewObjects[obj.id] = true
 
-			if (!oldHash) this.debug(`Cache: Object "${obj.id}" is new`)
-			else if (oldHash !== newHash) this.debug(`Cache: Object "${obj.id}" has changed`)
+			if (!oldHash) {
+				if (this.resolvedTimeline.traceResolving) {
+					this.resolvedTimeline.addResolveTrace(`cache: object "${obj.id}" is new`)
+				}
+			} else if (oldHash !== newHash) {
+				if (this.resolvedTimeline.traceResolving) {
+					this.resolvedTimeline.addResolveTrace(`cache: object "${obj.id}" has changed`)
+				}
+			}
 			if (
 				// Object is new:
 				!oldHash ||
@@ -61,7 +73,11 @@ export class CacheHandler {
 			} else {
 				// No timing-affecting changes detected
 				/* istanbul ignore if */
-				if (!oldHash) this.debug(`Cache: Object "${obj.id}" is similar`)
+				if (!oldHash) {
+					if (this.resolvedTimeline.traceResolving) {
+						this.resolvedTimeline.addResolveTrace(`cache: object "${obj.id}" is similar`)
+					}
+				}
 
 				// Even though the timeline-properties hasn't changed,
 				// the content (and other properties) might have:
@@ -69,8 +85,8 @@ export class CacheHandler {
 
 				/* istanbul ignore if */
 				if (!oldObj) {
-					console.error('oldHash', oldHash)
-					console.error('ids', Object.keys(this.cache.objects))
+					console.error(`oldHash: "${oldHash}"`)
+					console.error(`ids: ${JSON.stringify(Object.keys(this.cache.objects))}`)
 					throw new Error(`Internal Error: obj "${obj.id}" not found in cache, even though hashes match!`)
 				}
 
@@ -149,15 +165,28 @@ export class CacheHandler {
 			for (const reference of changedTracker.listChanged()) {
 				invalidator.invalidateObjectsWithReference(reference)
 			}
+			if (this.resolvedTimeline.traceResolving) {
+				this.resolvedTimeline.addResolveTrace(
+					`cache: changed references: ${JSON.stringify(Array.from(changedTracker.listChanged()))}`
+				)
+				this.resolvedTimeline.addResolveTrace(
+					`cache: invalidated objects: ${JSON.stringify(Array.from(invalidator.getInValidObjectIds()))}`
+				)
+				this.resolvedTimeline.addResolveTrace(
+					`cache: unchanged objects: ${JSON.stringify(invalidator.getValidObjects().map((o) => o.id))}`
+				)
+			}
 
 			// At this point, the objects that are left in validObjects are still valid (ie has not changed or is affected by any others).
 			// We can reuse the old resolving for those:
 			for (const obj of invalidator.getValidObjects()) {
-				if (!this.cache.objects[obj.id])
+				if (!this.cache.objects[obj.id]) {
 					/* istanbul ignore next */
 					throw new Error(
-						`Something went wrong: "${obj.id}" does not exist in cache.resolvedTimeline.objects`
+						`Internal Error: Something went wrong: "${obj.id}" does not exist in cache.resolvedTimeline.objects`
 					)
+				}
+
 				this.resolvedTimeline.objectsMap.set(obj.id, this.cache.objects[obj.id])
 			}
 		}
@@ -210,21 +239,26 @@ function getAllReferencesThisObjectAffects(newObj: ResolvedTimelineObject): Refe
 	}
 	return references
 }
+/**
+ * Keeps track of which timeline object have been changed
+ */
 class ChangedTracker {
 	private changedReferences = new Set<Reference>()
 
+	/**
+	 * Mark an object as "has changed".
+	 * Will store all references that are affected by this object.
+	 */
 	public addChangedObject(obj: ResolvedTimelineObject) {
-		const references = getAllReferencesThisObjectAffects(obj)
-		for (const ref of references) {
+		for (const ref of getAllReferencesThisObjectAffects(obj)) {
 			this.changedReferences.add(ref)
 		}
-		if (objHasLayer(obj)) {
-			this.changedReferences.add(`$${obj.layer}`)
-		}
 	}
+	/** Returns true if a reference has changed */
 	public isChanged(ref: Reference): boolean {
 		return this.changedReferences.has(ref)
 	}
+	/** Returns a list of all changed references */
 	public listChanged(): IterableIterator<Reference> {
 		return this.changedReferences.keys()
 	}
@@ -236,6 +270,7 @@ class Invalidator {
 	/** All references that depend on another reference (ie objects, class or layers): */
 	private affectReferenceMap: { [ref: Reference]: Reference[] } = {}
 	private validObjects: ResolvedTimelineObjects = {}
+	private inValidObjectIds: string[] = []
 	/** Map of which objects can be affected by any other object, per layer */
 	private objectLayerMap: { [layer: string]: string[] } = {}
 
@@ -244,6 +279,9 @@ class Invalidator {
 	}
 	public getValidObjects(): ResolvedTimelineObject[] {
 		return Object.values<ResolvedTimelineObject>(this.validObjects)
+	}
+	public getInValidObjectIds(): string[] {
+		return this.inValidObjectIds
 	}
 	public addObjectOnLayer(layer: string, obj: ResolvedTimelineObject) {
 		if (!this.objectLayerMap[layer]) this.objectLayerMap[layer] = []
@@ -263,6 +301,7 @@ class Invalidator {
 			const objId = getRefObjectId(reference)
 			if (this.validObjects[objId]) {
 				delete this.validObjects[objId]
+				this.inValidObjectIds.push(objId)
 			}
 		}
 		if (isLayerReference(reference)) {

--- a/src/resolver/ResolverHandler.ts
+++ b/src/resolver/ResolverHandler.ts
@@ -66,117 +66,16 @@ resolver.run(timeline);`
 		// Step 3: Go through and resolve all objects:
 		this.resolvedTimeline.resolveAllTimelineObjs()
 
-		// Step 4: Populate nextEvents:
-		this.updateNextEvents()
-
 		// Step 5: persist cache
 		if (cacheHandler) {
 			cacheHandler.persistData()
 		}
 
-		const resolvedTimeline = literal<ResolvedTimeline<TContent>>({
-			objects: mapToObject(this.resolvedTimeline.objectsMap),
-			classes: mapToObject(this.resolvedTimeline.classesMap),
-			layers: mapToObject(this.resolvedTimeline.layersMap),
-			nextEvents: this.nextEvents,
+		if (this.options.traceResolving) this.resolvedTimeline.addResolveTrace(`resolveTimeline done!`)
 
-			statistics: this.resolvedTimeline.getStatistics(),
+		const resolvedTimeline: ResolvedTimeline<TContent> = this.resolvedTimeline.getResolvedTimeline()
 
-			error: this.resolvedTimeline.resolveError,
-		})
 		toc()
 		return resolvedTimeline
 	}
-	/** Update this.nextEvents */
-	private updateNextEvents() {
-		const toc = tic('  updateNextEvents')
-		this.nextEvents = []
-
-		const allObjects: ResolvedTimelineObject[] = []
-		const allKeyframes: ResolvedTimelineObject[] = []
-
-		for (const obj of this.resolvedTimeline.objectsMap.values()) {
-			if (obj.resolved.isKeyframe) {
-				allKeyframes.push(obj)
-			} else {
-				allObjects.push(obj)
-			}
-		}
-
-		/** Used to fast-track in cases where there are no keyframes */
-		const hasKeyframes = allKeyframes.length > 0
-
-		const objectInstanceStartTimes = new Set<string>()
-		const objectInstanceEndTimes = new Set<string>()
-
-		// Go through keyframes last:
-		for (const obj of [...allObjects, ...allKeyframes]) {
-			if (!obj.resolved.isKeyframe) {
-				if (!objHasLayer(obj)) continue // transparent objects are omitted in NextEvents
-			} else if (obj.resolved.parentId !== undefined) {
-				const parentObj = this.resolvedTimeline.getObject(obj.resolved.parentId)
-				if (parentObj) {
-					/* istanbul ignore if */
-					if (!objHasLayer(parentObj)) continue // Keyframes of transparent objects are omitted in NextEvents
-				}
-			}
-
-			for (let i = 0; i < obj.resolved.instances.length; i++) {
-				const instance = obj.resolved.instances[i]
-				if (instance.start > this.options.time && instance.start < (this.options.limitTime ?? Infinity)) {
-					let useThis = true
-
-					if (hasKeyframes) {
-						if (!obj.resolved.isKeyframe) {
-							objectInstanceStartTimes.add(`${obj.id}_${instance.start}`)
-						} else {
-							// No need to put keyframe event if its parent starts at the same time:
-							if (objectInstanceStartTimes.has(`${obj.resolved.parentId}_${instance.start}`)) {
-								useThis = false
-							}
-						}
-					}
-
-					if (useThis) {
-						this.nextEvents.push({
-							objId: obj.id,
-							type: obj.resolved.isKeyframe ? EventType.KEYFRAME : EventType.START,
-							time: instance.start,
-						})
-					}
-				}
-				if (
-					instance.end !== null &&
-					instance.end > this.options.time &&
-					instance.end < (this.options.limitTime ?? Infinity)
-				) {
-					let useThis = true
-					if (hasKeyframes) {
-						if (!obj.resolved.isKeyframe) {
-							objectInstanceEndTimes.add(`${obj.id}_${instance.end}`)
-						} else {
-							// No need to put keyframe event if its parent ends at the same time:
-							if (objectInstanceEndTimes.has(`${obj.resolved.parentId}_${instance.end}`)) {
-								useThis = false
-							}
-						}
-					}
-
-					if (useThis) {
-						this.nextEvents.push({
-							objId: obj.id,
-							type: obj.resolved.isKeyframe ? EventType.KEYFRAME : EventType.END,
-							time: instance.end,
-						})
-					}
-				}
-			}
-		}
-		this.nextEvents.sort(compareNextEvents)
-		toc()
-	}
-}
-
-function compareNextEvents(a: NextEvent, b: NextEvent): number {
-	return a.time - b.time || b.type - a.type || compareStrings(a.objId, b.objId)
 }

--- a/src/resolver/ResolverHandler.ts
+++ b/src/resolver/ResolverHandler.ts
@@ -1,12 +1,11 @@
 import { ResolvedTimelineHandler } from './ResolvedTimelineHandler'
-import { EventType, NextEvent, ResolvedTimeline, ResolvedTimelineObject } from '../api/resolvedTimeline'
+import { ResolvedTimeline } from '../api/resolvedTimeline'
 import { ResolveOptions } from '../api/resolver'
 import { Content, TimelineObject } from '../api/timeline'
-import { compareStrings, literal, mapToObject } from './lib/lib'
 import { tic } from './lib/performance'
 import { CacheHandler } from './CacheHandler'
-import { objHasLayer } from './lib/timeline'
 import { TimelineValidator } from './TimelineValidator'
+import { ResolveError } from './lib/Error'
 
 /**
  * Note: A Resolver instance is short-lived and used to resolve a timeline.
@@ -17,8 +16,6 @@ import { TimelineValidator } from './TimelineValidator'
 export class ResolverHandler<TContent extends Content = Content> {
 	private hasRun = false
 
-	private nextEvents: NextEvent[] = []
-
 	private resolvedTimeline: ResolvedTimelineHandler<TContent>
 
 	private validator: TimelineValidator
@@ -27,6 +24,9 @@ export class ResolverHandler<TContent extends Content = Content> {
 		const toc = tic('new Resolver')
 		this.resolvedTimeline = new ResolvedTimelineHandler<TContent>(this.options)
 		this.validator = new TimelineValidator()
+		if (this.options.traceResolving) {
+			this.resolvedTimeline.addResolveTrace(`init`)
+		}
 		toc()
 	}
 	/**
@@ -34,48 +34,64 @@ export class ResolverHandler<TContent extends Content = Content> {
 	 * This method can only be run once per Resolver instance.
 	 */
 	public resolveTimeline(timeline: TimelineObject<TContent>[]): ResolvedTimeline<TContent> {
-		const toc = tic('resolveTimeline')
-		/* istanbul ignore if */
-		if (this.hasRun)
-			throw new Error(
-				`Resolver.resolveTimeline can only run once per instance!
-Usage:
-const resolver = new Resolver(options);
-resolver.run(timeline);`
-			)
-		this.hasRun = true
+		try {
+			const toc = tic('resolveTimeline')
+			/* istanbul ignore if */
+			if (this.hasRun) {
+				if (this.options.traceResolving) this.resolvedTimeline.addResolveTrace(`Error: has already run`)
+				throw new Error(
+					`Resolver.resolveTimeline can only run once per instance!
+	Usage:
+	const resolver = new Resolver(options);
+	resolver.run(timeline);`
+				)
+			}
+			this.hasRun = true
 
-		// Step 0: Validate the timeline:
-		if (!this.options.skipValidation) {
-			this.validator.validateTimeline(timeline, false)
+			if (this.options.traceResolving) {
+				this.resolvedTimeline.addResolveTrace(`resolveTimeline start`)
+				this.resolvedTimeline.addResolveTrace(`timeline object count ${timeline.length}`)
+			}
+
+			// Step 0: Validate the timeline:
+			if (!this.options.skipValidation) {
+				this.validator.validateTimeline(timeline, false)
+			}
+
+			// Step 1: Populate ResolvedTimeline with the timeline:
+			for (const obj of timeline) {
+				this.resolvedTimeline.addTimelineObject(obj)
+			}
+			if (this.options.traceResolving) {
+				this.resolvedTimeline.addResolveTrace(`objects: ${this.resolvedTimeline.objectsMap.size}`)
+			}
+
+			// Step 2: Use cache:
+			let cacheHandler: CacheHandler | undefined
+			if (this.options.cache) {
+				if (this.options.traceResolving) this.resolvedTimeline.addResolveTrace(`using cache`)
+
+				cacheHandler = this.resolvedTimeline.initializeCache(this.options.cache)
+
+				cacheHandler.determineChangedObjects()
+			}
+
+			// Step 3: Go through and resolve all objects:
+			this.resolvedTimeline.resolveAllTimelineObjs()
+
+			// Step 5: persist cache
+			if (cacheHandler) {
+				cacheHandler.persistData()
+			}
+
+			if (this.options.traceResolving) this.resolvedTimeline.addResolveTrace(`resolveTimeline done!`)
+
+			const resolvedTimeline: ResolvedTimeline<TContent> = this.resolvedTimeline.getResolvedTimeline()
+
+			toc()
+			return resolvedTimeline
+		} catch (e) {
+			throw new ResolveError(e, this.resolvedTimeline.getResolvedTimeline())
 		}
-
-		// Step 1: Populate ResolvedTimeline with the timeline:
-		for (const obj of timeline) {
-			this.resolvedTimeline.addTimelineObject(obj)
-		}
-
-		// Step 2: Use cache:
-		let cacheHandler: CacheHandler | undefined
-		if (this.options.cache) {
-			cacheHandler = this.resolvedTimeline.initializeCache(this.options.cache)
-
-			cacheHandler.determineChangedObjects()
-		}
-
-		// Step 3: Go through and resolve all objects:
-		this.resolvedTimeline.resolveAllTimelineObjs()
-
-		// Step 5: persist cache
-		if (cacheHandler) {
-			cacheHandler.persistData()
-		}
-
-		if (this.options.traceResolving) this.resolvedTimeline.addResolveTrace(`resolveTimeline done!`)
-
-		const resolvedTimeline: ResolvedTimeline<TContent> = this.resolvedTimeline.getResolvedTimeline()
-
-		toc()
-		return resolvedTimeline
 	}
 }

--- a/src/resolver/ResolverHandler.ts
+++ b/src/resolver/ResolverHandler.ts
@@ -91,6 +91,11 @@ export class ResolverHandler<TContent extends Content = Content> {
 			toc()
 			return resolvedTimeline
 		} catch (e) {
+			if (this.options.cache) {
+				// Reset cache, since it might be corrupt.
+				CacheHandler.resetCache(this.options.cache)
+			}
+
 			throw new ResolveError(e, this.resolvedTimeline.getResolvedTimeline())
 		}
 	}

--- a/src/resolver/StateHandler.ts
+++ b/src/resolver/StateHandler.ts
@@ -40,8 +40,8 @@ export class StateHandler {
 					/* istanbul ignore if */
 					if (state.layers[`${obj.layer}`]) {
 						// There is already an object on this layer!
-						console.error(state.layers[`${obj.layer}`])
-						console.error(objInstance)
+						console.error(`layer "${obj.layer}": ${JSON.stringify(state.layers[`${obj.layer}`])}`)
+						console.error(`object "${objInstance.id}": ${JSON.stringify(objInstance)}`)
 						throw new Error(`Internal Error: There is already an object on layer "${obj.layer}"!`)
 					}
 

--- a/src/resolver/lib/Error.ts
+++ b/src/resolver/lib/Error.ts
@@ -1,0 +1,12 @@
+import { ResolvedTimeline } from '../../api'
+
+export class ResolveError extends Error {
+	constructor(e: unknown, public readonly resolvedTimeline: ResolvedTimeline) {
+		super(e instanceof Error ? e.message : `${e}`)
+
+		this.name = 'ResolveError'
+		if (e instanceof Error) {
+			this.stack = e.stack
+		}
+	}
+}


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This is a Code improvement.


* **What is the new behavior?**

This PR replaces the debug-tracing to console.log, with logging to `resolvedTimeline.statistics.resolveTrace`.
It also changes a thrown `Error` into a `ResolveError` that contains the (partially resolved) `resolvedTimeline`.

This allows for a consumer of the Timeline resolver to try/catch and better log the `resolveTrace`, to figure out what might have gone wrong.

(This is an attempt to fix a `"Internal Error: There is already an object on layer"` issue in production, see [TSR PR](https://github.com/nrkno/sofie-timeline-state-resolver/pull/351).)


* **Other information**:
