### PR TITLE
chore: add a minimal test case showing regression from v8

### DIFF
--- a/src/__tests__/groups.spec.ts
+++ b/src/__tests__/groups.spec.ts
@@ -1617,6 +1617,45 @@ describeVariants(
 				},
 			])
 		})
+
+		test('Referencing and replacing a same-layer child of a group from the outside', () => {
+			const timeline = fixTimeline([
+				{
+					id: 'group',
+					enable: { start: 1000 },
+					priority: 0,
+					layer: '',
+					content: {},
+					children: [
+						{
+							id: 'obj_inside',
+							enable: { start: 0 },
+							layer: 'L1',
+							content: { value: 'wrong' },
+							priority: 0,
+						},
+					],
+					isGroup: true,
+				},
+				{
+					id: 'obj_outside',
+					enable: { start: '#obj_inside.start' },
+					layer: 'L1',
+					content: { value: 'right' },
+					priority: 1,
+				},
+			])
+			const time = 1000
+			const resolved = resolveTimeline(timeline, { time, cache: getCache() })
+
+			const state0 = getResolvedState(resolved, time)
+			expect(state0.time).toEqual(time)
+			expect(state0.layers).toMatchObject({
+				L1: {
+					content: { value: 'right' },
+				},
+			})
+		})
 	},
 	{
 		normal: true,


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds a test case, currently failing


* **What is the current behavior?** (You can also link to an open issue here)
A regression from v8 is observed, where an identical timeline would act as the test case asserts.
The issue lies in having an object outside of a group supposed to start with an object inside a group, while both of them are on the same layer. Currently neither of them will start, but in v8 `#obj_outside` would start.

* **What is the new behavior (if this is a feature change)?**
Just a test case added. No behavior change yet - needs fixing.


* **Other information**:
