### PR TITLE
feat: add shorthand reference to parent group

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ All objects will be on a **layer** in the resolved **state**. There are a few ru
 | Reference    | Description                                                         |
 | ------------ | ------------------------------------------------------------------- |
 | `#objId`     | Reference to the object that has the specified **.id**              |
-| `#@`         | Reference to the group that contains this object                    |
+| `##parent`   | Reference to the group that contains this object                    |
 | `.className` | Reference to any object that has the class-name in its **.classes** |
 | `$layerName` | Reference to any object that is on the specified layer (**.layer**) |
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ All objects will be on a **layer** in the resolved **state**. There are a few ru
 | Reference    | Description                                                         |
 | ------------ | ------------------------------------------------------------------- |
 | `#objId`     | Reference to the object that has the specified **.id**              |
+| `#@`         | Reference to the group that contains this object                    |
 | `.className` | Reference to any object that has the class-name in its **.classes** |
 | `$layerName` | Reference to any object that is on the specified layer (**.layer**) |
 

--- a/src/__tests__/groups.spec.ts
+++ b/src/__tests__/groups.spec.ts
@@ -1668,7 +1668,7 @@ describeVariants(
 					children: [
 						{
 							id: 'obj_inside',
-							enable: { start: 0, end: '#@.end - 1000' },
+							enable: { start: 0, end: '##parent.end - 1000' },
 							layer: 'L1',
 							content: {},
 							priority: 0,
@@ -1700,7 +1700,7 @@ describeVariants(
 					children: [
 						{
 							id: 'obj_inside',
-							enable: { start: 0, end: '#@.end - 1000' },
+							enable: { start: 0, end: '##parent.end - 1000' },
 							layer: 'L1',
 							content: {},
 							priority: 0,

--- a/src/__tests__/groups.spec.ts
+++ b/src/__tests__/groups.spec.ts
@@ -1656,6 +1656,79 @@ describeVariants(
 				},
 			})
 		})
+
+		test('Relative to end of parent group', () => {
+			const timeline = fixTimeline([
+				{
+					id: 'group',
+					enable: { start: 1000, end: 5000 },
+					priority: 0,
+					layer: '',
+					content: {},
+					children: [
+						{
+							id: 'obj_inside',
+							enable: { start: 0, end: '#@.end - 1000' },
+							layer: 'L1',
+							content: {},
+							priority: 0,
+						},
+					],
+					isGroup: true,
+				},
+			])
+			const time = 1000
+			const resolved = resolveTimeline(timeline, { time, cache: getCache() })
+
+			const obj_inside = resolved.objects['obj_inside']
+			expect(obj_inside).toBeTruthy()
+			expect(obj_inside.resolved.instances).toHaveLength(1)
+			expect(obj_inside.resolved.instances[0]).toMatchObject({
+				start: 1000,
+				end: 5000 - 1000,
+			})
+		})
+
+		test('Relative to end of parent group - interrupted', () => {
+			const timeline = fixTimeline([
+				{
+					id: 'group',
+					enable: { start: 1000 },
+					priority: 0,
+					layer: 'LG',
+					content: {},
+					children: [
+						{
+							id: 'obj_inside',
+							enable: { start: 0, end: '#@.end - 1000' },
+							layer: 'L1',
+							content: {},
+							priority: 0,
+						},
+					],
+					isGroup: true,
+				},
+				{
+					id: 'group2',
+					enable: { start: 5000 },
+					priority: 0,
+					layer: 'LG',
+					content: {},
+					children: [],
+					isGroup: true,
+				},
+			])
+			const time = 1000
+			const resolved = resolveTimeline(timeline, { time, cache: getCache() })
+
+			const obj_inside = resolved.objects['obj_inside']
+			expect(obj_inside).toBeTruthy()
+			expect(obj_inside.resolved.instances).toHaveLength(1)
+			expect(obj_inside.resolved.instances[0]).toMatchObject({
+				start: 1000,
+				end: 5000 - 1000,
+			})
+		})
 	},
 	{
 		normal: true,

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -14,5 +14,5 @@ export type ObjectReference = `#${string}`
 export type ClassReference = `.${string}`
 export type LayerReference = `$${string}`
 export type InstanceReference = `@${InstanceId}`
-export type ParentReference = '#@'
+export type ParentReference = '##parent'
 export type Reference = ObjectReference | ClassReference | LayerReference | InstanceReference | ParentReference

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -14,4 +14,5 @@ export type ObjectReference = `#${string}`
 export type ClassReference = `.${string}`
 export type LayerReference = `$${string}`
 export type InstanceReference = `@${InstanceId}`
-export type Reference = ObjectReference | ClassReference | LayerReference | InstanceReference
+export type ParentReference = '#@'
+export type Reference = ObjectReference | ClassReference | LayerReference | InstanceReference | ParentReference

--- a/src/resolver/ReferenceHandler.ts
+++ b/src/resolver/ReferenceHandler.ts
@@ -78,13 +78,13 @@ export class ReferenceHandler {
 
 			let referenceIsOk = false
 			// Match id, example: "#objectId.start"
-			const m = /^\W*#([^.]+)(.*)/.exec(expr)
+			const m = /^[^\w#.$]*#([^.]+)(.*)/.exec(expr)
 			if (m) {
 				let id = m[1]
 				rest = m[2]
 
-				// Special case: if the id is '@', use the parent id
-				if (id === '@') id = obj.resolved.parentId || id
+				// Special case: if the id is '#parent', use the parent id
+				if (id === '#parent') id = obj.resolved.parentId || id
 
 				referenceIsOk = true
 				objIdsToReference = [id]

--- a/src/resolver/ReferenceHandler.ts
+++ b/src/resolver/ReferenceHandler.ts
@@ -80,8 +80,11 @@ export class ReferenceHandler {
 			// Match id, example: "#objectId.start"
 			const m = /^\W*#([^.]+)(.*)/.exec(expr)
 			if (m) {
-				const id = m[1]
+				let id = m[1]
 				rest = m[2]
+
+				// Special case: if the id is '@', use the parent id
+				if (id === '@') id = obj.resolved.parentId || id
 
 				referenceIsOk = true
 				objIdsToReference = [id]

--- a/src/resolver/ResolvedTimelineHandler.ts
+++ b/src/resolver/ResolvedTimelineHandler.ts
@@ -21,6 +21,7 @@ import {
 	isInstanceReference,
 	isLayerReference,
 	isObjectReference,
+	isParentReference,
 	joinReferences,
 } from './lib/reference'
 import { EventForInstance, InstanceEvent, sortEvents } from './lib/event'
@@ -908,7 +909,10 @@ export class ResolvedTimelineHandler<TContent extends Content = Content> {
 
 		for (const ref of directReferences) {
 			const objectsThisIsReferencing: string[] = []
-			if (isObjectReference(ref)) {
+			if (isParentReference(ref)) {
+				const parentObjId = obj.resolved.parentId
+				if (parentObjId) objectsThisIsReferencing.push(parentObjId)
+			} else if (isObjectReference(ref)) {
 				const objId = getRefObjectId(ref)
 				objectsThisIsReferencing.push(objId)
 			} else if (isClassReference(ref)) {

--- a/src/resolver/lib/reference.ts
+++ b/src/resolver/lib/reference.ts
@@ -4,6 +4,7 @@ import {
 	InstanceReference,
 	LayerReference,
 	ObjectReference,
+	ParentReference,
 	Reference,
 	TimelineObjectInstance,
 } from '../../api'
@@ -20,6 +21,9 @@ export function isObjectReference(ref: Reference): ref is ObjectReference {
 }
 export function getRefObjectId(ref: ObjectReference): string {
 	return ref.slice(1)
+}
+export function isParentReference(ref: Reference): ref is ParentReference {
+	return ref == '#@'
 }
 
 export function isClassReference(ref: Reference): ref is ClassReference {

--- a/src/resolver/lib/reference.ts
+++ b/src/resolver/lib/reference.ts
@@ -23,7 +23,7 @@ export function getRefObjectId(ref: ObjectReference): string {
 	return ref.slice(1)
 }
 export function isParentReference(ref: Reference): ref is ParentReference {
-	return ref == '#@'
+	return ref == '##parent'
 }
 
 export function isClassReference(ref: Reference): ref is ClassReference {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature


* **What is the new behavior (if this is a feature change)?**

This adds a shorthand notation for making references to the parent group that an object belongs to.  
This is intended to allow for timing objects to the end of the parent group, without needing to know the id of that group.


* **Other information**:

I am not 100% sure of the syntax proposed here, maybe there is a better character to use? Equally, I think this makes some sense as its pretending to be a id reference to `@`, which conceptually matches what it is doing.

I am not at all confident in this implementation, I probably have missed some cases in caching or something. Some pointers on more things/cases to test would be appreciated
