### PR TITLE
fix: Add missing object id reference to the thrown Validator errors

### DIFF
--- a/src/resolver/TimelineValidator.ts
+++ b/src/resolver/TimelineValidator.ts
@@ -86,7 +86,7 @@ export class TimelineValidator {
 			if (err instanceof Error) {
 				const err2 = new Error(`Object "${obj.id}": ${err.message}`)
 				err2.stack = err.stack
-				throw err
+				throw err2
 			} else throw err
 		}
 	}

--- a/src/resolver/__tests__/TimelineValidator.spec.ts
+++ b/src/resolver/__tests__/TimelineValidator.spec.ts
@@ -54,3 +54,21 @@ test('validateReferenceString', () => {
 		/contains characters which aren't allowed in Timeline: "-" \(is an operator\), "§", "=" \(is a strict reserved character/
 	)
 })
+test('validateObject', () => {
+	const validator = new TimelineValidator()
+	expect(() =>
+		validator.validateObject(
+			{
+				id: 'obj0',
+				content: {},
+				enable: {
+					start: 0,
+					duration: 0,
+					end: 0, // end and duration cannot be combined
+				},
+				layer: 'L1',
+			},
+			true
+		)
+	).toThrow(/obj0.*end.*duration.*cannot be combined/)
+})


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Minor bug fix in thrown error message


* **What is the current behavior?** (You can also link to an open issue here)
The TimelineValidator throws error with message `"enable.while" and "enable.end" cannot be combined`


* **What is the new behavior (if this is a feature change)?**

The TimelineValidator throws error with message `Object "xyz": "enable.while" and "enable.end" cannot be combined`


* **Other information**:
