### PR TITLE
Bug: Object that collide with object that depend on colliding object

### DIFF
--- a/src/__tests__/basic.spec.ts
+++ b/src/__tests__/basic.spec.ts
@@ -1854,6 +1854,81 @@ describeVariants(
 				},
 			})
 		})
+		test('Object that depend on object that depend on colliding object', () => {
+			// An object that start at the same time as another should behave as expected
+			//
+			const timeline = fixTimeline([
+				{
+					id: 'A',
+					enable: {
+						start: 20,
+					},
+					layer: 'layer1',
+					content: {},
+				},
+				{
+					id: 'B',
+					enable: {
+						start: 10,
+					},
+					layer: 'layer1',
+					classes: ['myClass'],
+					content: {},
+				},
+				{
+					id: 'C',
+					enable: {
+						while: '.myClass',
+					},
+					priority: 1,
+					layer: 'layer0',
+					content: {},
+				},
+				{
+					id: 'D',
+					enable: {
+						while: 1,
+					},
+					priority: 0,
+					layer: 'layer0',
+					content: {},
+				},
+			])
+			// Expected behavior:
+			// A plays from 20 to null
+			// B plays from 10 to 20 (due to colliding with A)
+			// C plays from 10 to 20 (same as B)
+			// D plays from 0 to 10, then 20 to null (due to collision with C)
+
+			const time = 0
+			const resolved = resolveTimeline(timeline, { time, cache: getCache() })
+
+			expect(resolved.objects).toMatchObject({
+				A: {
+					resolved: {
+						instances: [{ start: 20, end: null }],
+					},
+				},
+				B: {
+					resolved: {
+						instances: [{ start: 10, end: 20 }],
+					},
+				},
+				C: {
+					resolved: {
+						instances: [{ start: 10, end: 20 }],
+					},
+				},
+				D: {
+					resolved: {
+						instances: [
+							{ start: 0, end: 10 },
+							{ start: 20, end: null },
+						],
+					},
+				},
+			})
+		})
 	},
 	{
 		normal: true,

--- a/src/resolver/LayerStateHandler.ts
+++ b/src/resolver/LayerStateHandler.ts
@@ -36,7 +36,7 @@ export class LayerStateHandler {
 		const toc = tic('       resolveConflicts')
 
 		/*
-			This algoritm basically works like this:
+			This algorithm basically works like this:
 
 			1. Collect all instances start- and end-times as points-of-interest
 			2. Sweep through the points-of-interest and determine which instance is the "winning one" at every point in time


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix


## What is the current behavior?

(see unit test)

If an object (A) collides with object (B) that depends on object (C) that is affected by a collision with object (D);
Object A might get the wrong resolved result in certain cases.

This bug only happens in a certain order of objects in the timeline as well as if the names of the layers are in a certain alphabetical order.

## What is the new behavior?

When a collision results in re-resolving, all other objects on that layer are also re-resolved.

This fixes the bug, but also decreases performance:

`yarn unit performance` results:

* Before: 3.6 ms
* After: 5.2 ms

