### PR TITLE
Fix: Bug when referencing a colliding object

### DIFF
--- a/src/__tests__/basic.spec.ts
+++ b/src/__tests__/basic.spec.ts
@@ -1933,48 +1933,46 @@ describeVariants(
 		test('Object colliding with its start reference', () => {
 			const tl0 = fixTimeline([
 				{
-					id: 'EetprnQcvGncgkg0ZUG4jQwQpzM_',
-					enable: {
-						while: '.casparcg_next_clip_stk',
-					},
-					priority: 1,
-					layer: 'casparcg_player_clip_stk_next',
-					content: {},
-				},
-
-				{
-					id: 'from_previous_part',
-					priority: 0,
-					enable: {
-						start: 1000,
-					},
-					layer: 'casparcg_player_clip_next_select',
-					classes: ['casparcg_next_clip_stk'],
-					content: {},
-				},
-
-				{
-					id: 'new_part_obj',
+					id: 'A',
 					priority: 0, // Putting this above 0.05 avoids the issue
 					enable: {
 						start: 5000,
 						duration: 1,
 					},
-					layer: 'casparcg_player_clip_next_select',
-					classes: ['casparcg_next_clip_stk'],
+					layer: 'L1',
+					classes: ['class0'],
+					content: {},
+				},
+				{
+					id: 'B',
+					enable: {
+						while: '.class0',
+					},
+					priority: 1,
+					layer: 'L0',
 					content: {},
 				},
 
 				{
-					id: 'lookahead_future0',
+					id: 'C',
+					priority: 0,
+					enable: {
+						start: 1000,
+					},
+					layer: 'L1',
+					classes: ['class0'],
+					content: {},
+				},
+
+				{
+					id: 'D',
 					priority: 0.05,
 					enable: {
-						start: '#new_part_obj.start + 0',
+						start: '#C.start',
 					},
-					layer: 'casparcg_player_clip_next_select',
-					classes: ['casparcg_next_clip_stk'],
+					layer: 'L1',
+					classes: ['class0'],
 					content: {},
-					disabled: false,
 				},
 			])
 

--- a/src/__tests__/basic.spec.ts
+++ b/src/__tests__/basic.spec.ts
@@ -1929,6 +1929,67 @@ describeVariants(
 				},
 			})
 		})
+
+		test('Object colliding with its start reference', () => {
+			const tl0 = fixTimeline([
+				{
+					id: 'EetprnQcvGncgkg0ZUG4jQwQpzM_',
+					enable: {
+						while: '.casparcg_next_clip_stk',
+					},
+					priority: 1,
+					layer: 'casparcg_player_clip_stk_next',
+					content: {},
+				},
+
+				{
+					id: 'from_previous_part',
+					priority: 0,
+					enable: {
+						start: 1000,
+					},
+					layer: 'casparcg_player_clip_next_select',
+					classes: ['casparcg_next_clip_stk'],
+					content: {},
+				},
+
+				{
+					id: 'new_part_obj',
+					priority: 0, // Putting this above 0.05 avoids the issue
+					enable: {
+						start: 5000,
+						duration: 1,
+					},
+					layer: 'casparcg_player_clip_next_select',
+					classes: ['casparcg_next_clip_stk'],
+					content: {},
+				},
+
+				{
+					id: 'lookahead_future0',
+					priority: 0.05,
+					enable: {
+						start: '#new_part_obj.start + 0',
+					},
+					layer: 'casparcg_player_clip_next_select',
+					classes: ['casparcg_next_clip_stk'],
+					content: {},
+					disabled: false,
+				},
+			])
+
+			const sample = 5000
+
+			const resolved = resolveTimeline(tl0, { time: sample, cache: getCache() })
+
+			// const obj0 = resolved.objects['new_part_obj']
+			// const obj1 = resolved.objects['lookahead_future0']
+
+			// console.log('obj0', JSON.stringify(obj0, undefined, '\t'))
+			// console.log('obj1', JSON.stringify(obj1, undefined, '\t'))
+
+			getResolvedState(resolved, sample)
+		})
 	},
 	{
 		normal: true,

--- a/src/resolver/ResolvedTimelineHandler.ts
+++ b/src/resolver/ResolvedTimelineHandler.ts
@@ -178,23 +178,11 @@ export class ResolvedTimelineHandler<TContent extends Content = Content> {
 				)
 			}
 
-			// Collect and reset all objects that depend on previously changed objects
-			const conflictObjectsToResolve: ResolvedTimelineObject[] = []
-			for (const obj of this.objectsToReResolve.values()) {
+			// Re-resolve all objects that might have changed (due to conflicts):
+			const conflictObjectsToResolve: ResolvedTimelineObject[] = Array.from(this.objectsToReResolve.values())
+			for (const obj of conflictObjectsToResolve) {
 				this.objectResolveCount++
-
-				// Force a new resolve, since the referenced objects might have changed (due to conflicts):
-				let needsConflictResolve = false
-				if (!obj.resolved.resolvedReferences) {
-					this.resolveTimelineObj(obj)
-					needsConflictResolve = true
-				}
-				if (!obj.resolved.resolvedConflicts) {
-					needsConflictResolve = true
-				}
-				if (needsConflictResolve) {
-					conflictObjectsToResolve.push(obj)
-				}
+				this.resolveTimelineObj(obj)
 			}
 			if (this._resolveError) return // Abort on error
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)

In certain scenarios, the resolving of a timeline crashes with an `Internal Error: There is already an object on layer`.
See unit test.

* **What is the new behavior (if this is a feature change)?**

Resolving succeeds.


* **Other information**:
